### PR TITLE
Fix #698 - Sketches weren't opening on launch because the untitled folder did not exist yet

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1214,6 +1214,7 @@ public class Base {
   private Editor openSketchBundle(String path) {
     File zipFile = new File(path);
     try {
+      untitledFolder.mkdirs();
       File destFolder = File.createTempFile("zip", "tmp", untitledFolder);
       if (!destFolder.delete() || !destFolder.mkdirs()) {
         // Hard to imagine why this would happen, but...


### PR DESCRIPTION
Fixes #698 