### PR TITLE
Improvements to Debug Processing:Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ processing-examples
 .gradle
 core/build/
 build/publish/
+/app/build
+/java/build

--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,17 @@
+# Processing Core
+
+Welcome to the Core of Processing, this is the code that will be inlcuded in your sketches and is responsible for methods like `ellipse()` and `background()`.
+
+
+
+## Developing Core
+
+Since processing 4.3.1 we have started moving to a gradle build system for core. 
+
+### Building and Debugging core
+Open the project in IntelliJ IDEA. Then you can go into the `src/processing/sketches` folder and run any of the sketches to test the core. This only supported in the  IntelliJ editor for now, we will add support for other editors and command line at a later date.
+
+
 ## There are significant changes to `core` in Processing 3.
 
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 sourceSets{
     main{
         java{
-            srcDirs("src/processing")
+            srcDirs("src")
         }
         resources{
             srcDirs("src")

--- a/core/src/processing/sketches/Basic.java
+++ b/core/src/processing/sketches/Basic.java
@@ -1,0 +1,27 @@
+package processing.sketches;
+
+import processing.core.PApplet;
+
+public class Basic extends PApplet {
+
+    public void settings(){
+        size(800, 800);
+    }
+    public void setup(){
+
+    }
+
+    public void draw(){
+
+    }
+
+    public static void main(String[] passedArgs) {
+        String[] appletArgs = new String[]{Basic.class.getName()};
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+
+    }
+}


### PR DESCRIPTION
We need a way to debug / run sketches independently of the Processing IDE. Later I would like to add the ability to debug sketches through the PDE, e.g. Run a sketch in the PDE and IntelliJ will attach the debugger to the ran sketch