### PR TITLE
Add all seven of the javafx modules to JavaBuild.java

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -1083,7 +1083,9 @@ public class JavaBuild {
       // Full list of modules, let's not commit to all of these unless
       // a compelling argument is made or a reason presents itself.
       //"javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web"
-      "--add-modules", "javafx.base,javafx.graphics,javafx.swing",
+     // "--add-modules", "javafx.base,javafx.graphics,javafx.swing",
+// ***** change to:
+       "--add-modules", "javafx.base,javafx.graphics,javafx.swing,javafx.controls,javafx.media,javafx.web,javafx.fxml",
 
       // TODO Presumably, this is only because com.sun.* classes are being used?
       // https://github.com/processing/processing4/issues/208

--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -1083,8 +1083,6 @@ public class JavaBuild {
       // Full list of modules, let's not commit to all of these unless
       // a compelling argument is made or a reason presents itself.
       //"javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web"
-     // "--add-modules", "javafx.base,javafx.graphics,javafx.swing",
-// ***** change to:
        "--add-modules", "javafx.base,javafx.graphics,javafx.swing,javafx.controls,javafx.media,javafx.web,javafx.fxml",
 
       // TODO Presumably, this is only because com.sun.* classes are being used?

--- a/vsquared-patch-1
+++ b/vsquared-patch-1
@@ -1,0 +1,5 @@
+In JavaBuild.java line 1086
+change this line:
+ "--add-modules", "javafx.base,javafx.graphics,javafx.swing",
+to this:
+ "--add-modules", "javafx.base,javafx.graphics,javafx.swing,javafx.controls,javafx.media,javafx.web,javafx.fxml",

--- a/vsquared-patch-1
+++ b/vsquared-patch-1
@@ -1,5 +1,0 @@
-In JavaBuild.java line 1086
-change this line:
- "--add-modules", "javafx.base,javafx.graphics,javafx.swing",
-to this:
- "--add-modules", "javafx.base,javafx.graphics,javafx.swing,javafx.controls,javafx.media,javafx.web,javafx.fxml",


### PR DESCRIPTION
Please add _all seven of the javafx modules so that we may use JavaFX controls in our apps. Thanks.

Closes https://github.com/processing/processing4-javafx/issues/17
Closes https://github.com/processing/processing4-javafx/issues/15