### PR TITLE
Update core/README.md on how to use the core library from Maven Central.

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,65 @@
+# Including the Processing Core library on your project
+Processing’s core libraries are available through [Maven Central](https://central.sonatype.com/artifact/org.processing/core).  
+This allows integration of Processing into Java-based projects using build tools like Maven or Gradle.
+
+> [!IMPORTANT]  
+> Repository https://jogamp.org/deployment/maven must be added to the repository list.
+>
+> This is because the core library depends on some external libraries that are hosted on the aftermentioned repository.  
+> See the [Examples](#Examples) section on how to do this.
+
+## Examples
+Here are some examples on how to add the Processing core library to the Maven and Gradle build systems.  
+All examples consist on two parts:
+1. Adds the https://jogamp.org/deployment/maven repository to the build system to satisfy dependencies needed by the Processing core library.
+2. Adds the Processing core library as a dependency to your project.
+### Maven
+```xml
+<repositories>
+  <repository>
+    <id>jogamp</id>
+    <url>https://jogamp.org/deployment/maven</url>
+  </repository>
+</repositories>
+
+<dependencies>
+  <dependency>
+    <groupId>org.processing</groupId>
+    <artifactId>core</artifactId>
+    <version>4.3.1</version>
+  </dependency>
+</dependencies>
+```
+### Gradle (kotlin)
+```gradle
+repositories {
+  mavenCentral()
+  maven {
+      url = uri("https://jogamp.org/deployment/maven")
+  }
+}
+
+dependencies {
+  implementation("org.processing:core:4.3.1")
+}
+```
+### Gradle (groovy)
+```gradle
+repositories {
+  mavenCentral()
+  maven {
+      url = uri("https://jogamp.org/deployment/maven")
+  }
+}
+
+dependencies {
+  implementation group: 'org.processing', name: 'core', version: '4.3.1'
+}
+```
+### Other
+Other example snippets on including the library are included in the [Maven Central repo](https://central.sonatype.com/artifact/org.processing/core).  
+Please look up on how to add the custom https://jogamp.org/deployment/maven repository to your build system.
+
 ## There are significant changes to `core` in Processing 3.
 
 


### PR DESCRIPTION
Adds a section on top of [core/README.md](https://github.com/processing/processing4/blob/main/core/README.md) that explains how to include the Processing core library from Maven Central with examples on the Maven and Gradle build tools.