### PR TITLE
4.3.1 arm64 fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+      - name: Checkout Examples Repository
+        uses: actions/checkout@v4
+        with:
+          repository: processing/processing-examples
+          path: processing-examples
       - name: Install Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
       - name: Build Release
-        run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ needs.version.outputs.version }}" -Dplatform.override=${{ matrix.os_prefix }}
+        run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ needs.version.outputs.version }}" -Dplatform=${{ matrix.os_prefix }}
         env:
           PROCESSING_APP_PASSWORD: ${{ secrets.PROCESSING_APP_PASSWORD }}
           PROCESSING_APPLE_ID: ${{ secrets.PROCESSING_APPLE_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           # compiling for arm32 needs a self-hosted runner on Raspi OS (32-bit)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
       - name: Build Release
-        run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ needs.version.outputs.version }}"
+        run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ needs.version.outputs.version }}" -Dplatform.override=${{ matrix.os_prefix }}
         env:
           PROCESSING_APP_PASSWORD: ${{ secrets.PROCESSING_APP_PASSWORD }}
           PROCESSING_APPLE_ID: ${{ secrets.PROCESSING_APPLE_ID }}

--- a/build/build.xml
+++ b/build/build.xml
@@ -9,13 +9,6 @@
     </classpath>
   </taskdef>
 
-  <property name="platform.override" value="" description="Override OS (windows/linux/mac)" />
-
-  <!-- First check if we have an override -->
-  <condition property="platform" value="${platform.override}">
-    <isset property="platform.override"/>
-  </condition>
-
   <!-- Only do OS detection if platform isn't already set by override -->
   <condition property="platform" value="macos">
     <and>

--- a/build/build.xml
+++ b/build/build.xml
@@ -9,21 +9,37 @@
     </classpath>
   </taskdef>
 
-  <!-- Sets properties for macos/windows/linux depending on current system -->
+  <property name="platform.override" value="" description="Override OS (windows/linux/mac)" />
+
+  <!-- First check if we have an override -->
+  <condition property="platform" value="${platform.override}">
+    <isset property="platform.override"/>
+  </condition>
+
+  <!-- Only do OS detection if platform isn't already set by override -->
   <condition property="platform" value="macos">
-    <os family="mac" />
+    <and>
+      <not><isset property="platform"/></not>
+      <os family="mac" />
+    </and>
   </condition>
 
   <condition property="platform" value="windows">
-    <os family="windows" />
+    <and>
+      <not><isset property="platform"/></not>
+      <os family="windows" />
+    </and>
   </condition>
 
   <condition property="platform" value="linux">
     <and>
-      <os family="unix" />
-      <not>
-        <os family="mac" />
-      </not>
+      <not><isset property="platform"/></not>
+      <and>
+        <os family="unix" />
+        <not>
+          <os family="mac" />
+        </not>
+      </and>
     </and>
   </condition>
 
@@ -114,7 +130,7 @@
 
     <!-- ${platform} ok for Windows/Linux, but 'macos' needs to be 'mac' -->
     <condition property="jdk.download.os" value="mac" else="${platform}">
-      <os family="mac" />
+      <equals arg1="${platform}" arg2="macos"/>
     </condition>
 
     <!-- amd64 or x86_64 use x64, others use os.arch -->


### PR DESCRIPTION
Because we were building the ARM64 build of processing on a macOS arm runner, the build.xml file assumed that this was a macOS build and included the macOS jdk instead of the linux one, this request fixes that. Hopefully fixing https://github.com/processing/processing4/issues/865 