### PR TITLE
Sign macos prebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,16 @@ jobs:
           architecture: ${{ matrix.arch }}
       - name: Setup Ant
         uses: cedx/setup-ant@v3
+      - name: Install Certificates for Code Signing
+        if: ${{ matrix.os_prefix == 'macos' }}
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
       - name: Build Release
         run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ github.sha }}"
+        with:
+          PROCESSING_APP_SIGNING: true
       - name: Add artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
       - name: Build Release
         run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ github.sha }}"
-        with:
+        env:
           PROCESSING_APP_SIGNING: true
       - name: Add artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,8 +51,16 @@ jobs:
           architecture: ${{ matrix.arch }}
       - name: Setup Ant
         uses: cedx/setup-ant@v3
+      - name: Install Certificates for Code Signing
+        if: ${{ matrix.os_prefix == 'macos' }}
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
       - name: Build Release
         run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ github.sha }}"
+        with:
+          PROCESSING_APP_SIGNING: true
       - name: Add artifact
         uses: actions/upload-artifact@v3
         id: upload

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,7 +59,7 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
       - name: Build Release
         run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ github.sha }}"
-        with:
+        env:
           PROCESSING_APP_SIGNING: true
       - name: Add artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Build Release
         run: ant -noinput -buildfile build/build.xml ${{ matrix.os_prefix }}-dist -Dversion="${{ needs.version.outputs.version }}"
         env:
+          PROCESSING_APP_SIGNING: true
           PROCESSING_APP_PASSWORD: ${{ secrets.PROCESSING_APP_PASSWORD }}
           PROCESSING_APPLE_ID: ${{ secrets.PROCESSING_APPLE_ID }}
           PROCESSING_TEAM_ID: ${{ secrets.PROCESSING_TEAM_ID }}

--- a/build/build.xml
+++ b/build/build.xml
@@ -778,7 +778,7 @@
     </exec>
   </target>
 
-  <target name="macos-dist-sign" if="env.PROCESSING_APP_PASSWORD | env.PROCESSING_APP_SIGNING">
+  <target name="macos-dist-sign" if="env.PROCESSING_APP_SIGNING">
     <echo>
       Code signing will only work if you have a $99/yr Apple developer ID.
     </echo>

--- a/build/build.xml
+++ b/build/build.xml
@@ -778,7 +778,7 @@
     </exec>
   </target>
 
-  <target name="macos-dist-sign" if="env.PROCESSING_APP_PASSWORD">
+  <target name="macos-dist-sign" if="env.PROCESSING_APP_PASSWORD | env.PROCESSING_APP_SIGNING">
     <echo>
       Code signing will only work if you have a $99/yr Apple developer ID.
     </echo>


### PR DESCRIPTION
Signing the macOS pre-builds so we can test pre-releases on our own machines. Unfortunately signing the application is not enough and we need to notarise it if we want it to be able to be run. From here we have two options:
- Notarise pre-builds anyway, I dislike this option as it allows for unverified software to be distributed by under the Processing Foundation's name
- Instruct people to use the following hack: `xattr -d com.apple.quarantine ./Processing.app` this is a more advanced use case but the people who need to check beta software could be expected to jump through this hoop...

If anyone has any input let me know