### PR TITLE
Fix JAVA2D problem in shapes with multiple contours

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1783,6 +1783,7 @@ public class PShape implements PConstants {
             g.endContour();
           }
           g.beginContour();
+          codeIndex++;
           insideContour = true;
         }
 
@@ -1795,6 +1796,7 @@ public class PShape implements PConstants {
             g.endContour();
           }
           g.beginContour();
+          codeIndex++;
           insideContour = true;
         }
 


### PR DESCRIPTION
This is a fix for issue #791 that I opened after I discovered my fix for #643 was inadequate.

## Explanation

The JAVA2D renderer should be able to draw contours just like the P2D renderer.

The contours are messed up because the `codeIndex` variable needs to be incremented when starting a contour to keep the `vertexCodes` array aligned with the vertices array.

You can test the fix with this code:

```java

PShape s;

void setup() {
  size(400, 200);
  fill(255, 0, 0);
  noLoop();
}

void draw() {
  translate(50, 50);
  s = createShape();
  s.beginShape();
  s.fill(255, 0, 0);
  s.vertex(  0, 0);
  s.vertex(100, 0);
  s.vertex(100, 100);
  s.vertex(  0, 100);

  for (int x = 5; x <= 85; x += 20) {
    for (int y = 5; y <= 85; y += 20) {
      s.beginContour();
      s.vertex(x, y);
      s.vertex(x, y + 10);
      s.vertex(x + 10, y + 10);
      s.vertex(x + 10, y);
      s.endContour();
    }
  }

  s.endShape(CLOSE);
  shape(s, 0, 0);

  translate(200, 0);

  beginShape();
  fill(255, 0, 0);
  vertex( 0, 0);
  vertex(100, 0);
  vertex(100, 100);
  vertex(0, 100);

  for (int x = 5; x <= 85; x += 20) {
    for (int y = 5; y <= 85; y += 20) {
      beginContour();
      vertex(x, y);
      vertex(x, y + 10);
      vertex(x + 10, y + 10);
      vertex(x + 10, y);
      endContour();
    }
  }
 
  endShape(CLOSE);
}
```
