### PR TITLE
Refactor SVG path parser to accept scientific notation

### DIFF
--- a/core/src/processing/core/PShapeSVG.java
+++ b/core/src/processing/core/PShapeSVG.java
@@ -515,6 +515,7 @@ public class PShapeSVG extends PShape {
 
     StringBuilder pathBuffer = new StringBuilder();
 
+    // The states of the lexical sanner
     enum LexState {
       AFTER_CMD,// Just after a command (i.e. a single alphabet)
       NEUTRAL,  // Neutral state, waiting for a number expression or a command
@@ -523,15 +524,6 @@ public class PShapeSVG extends PShape {
       EXP_HEAD, // On the head of the exponent part of a scientific notation; the '-' sign or a digit
       EXP_TAIL, // On the integer expression in the exponent part
     }
-    /*
-     * The state of the lexer:
-     * -1: just after the command (i.e. a single alphabet)
-     * 0: neutral state
-     * 1: on a digit sequence for integer representation
-     * 2: on a decimal
-     * 3: on a digit or a sign in exponent in scientific notation, e.g. 3.14e-2)
-     * 4: on a digit sequence in exponent
-     */
     LexState lexState = LexState.NEUTRAL;
 
     for (int i = 0; i < pathDataChars.length; i++) {

--- a/core/test/processing/core/PShapeSVGTest.java
+++ b/core/test/processing/core/PShapeSVGTest.java
@@ -10,23 +10,47 @@ import java.awt.*;
 
 public class PShapeSVGTest {
 
-  private static final String TEST_CONTENT = "<svg><g><path d=\"L 0,3.1.4.1\"/></g></svg>";
+  private static final String[] TEST_CONTENT = {
+    "<svg><g><path d=\"L 0,3.1.4.1\"/></g></svg>",
+    "<svg><g><path d=\"m-13.6 4.69-1.35 0.78h-0.00034l1.33 2.27 1.33-0.77a6.48 6.47 43.14 0 1-1.31-2.27z\"/></g></svg>"
+  };
+  private static final int[] TEST_NVERTEX = {2, 8};
+  private static final String TEST_EXPONENT =
+    "<svg><g><path d=\"m-1.36E1 469e-2-1.35 0.78h-3.4e-4l1.33 2.27 1.33-0.77a6.48 6.47 43.14 0 1-1.31-2.27z\"/></g></svg>";
 
   @Test
   public void testDecimals() {
     try {
-      XML xml = XML.parse(TEST_CONTENT);
-      PShapeSVG shape = new PShapeSVG(xml);
-      PShape[] children = shape.getChildren();
-      Assert.assertEquals(1, children.length);
-      PShape[] grandchildren = children[0].getChildren();
-      Assert.assertEquals(1, grandchildren.length);
-      Assert.assertEquals(0, grandchildren[0].getChildCount());
-      Assert.assertEquals(2, grandchildren[0].getVertexCount());
+      for (int i = 0; i < TEST_CONTENT.length; ++i) {
+        XML xml = XML.parse(TEST_CONTENT[i]);
+        PShapeSVG shape = new PShapeSVG(xml);
+        PShape[] children = shape.getChildren();
+        Assert.assertEquals(1, children.length);
+        PShape[] grandchildren = children[0].getChildren();
+        Assert.assertEquals(1, grandchildren.length);
+        Assert.assertEquals(0, grandchildren[0].getChildCount());
+        Assert.assertEquals(TEST_NVERTEX[i], grandchildren[0].getVertexCount());
+      }
     }
     catch (Exception e) {
       Assert.fail("Encountered exception " + e);
     }
   }
 
+  @Test
+  public void testExponent() {
+    try {
+      XML xml = XML.parse(TEST_EXPONENT);
+      PShapeSVG shape = new PShapeSVG(xml);
+      PShape[] children = shape.getChildren();
+      Assert.assertEquals(1, children.length);
+      PShape[] grandchildren = children[0].getChildren();
+      Assert.assertEquals(1, grandchildren.length);
+      Assert.assertEquals(0, grandchildren[0].getChildCount());
+      Assert.assertEquals(8, grandchildren[0].getVertexCount());
+    }
+    catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+  }
 }


### PR DESCRIPTION
Refactor `PShapeSVG.parsePath()` so that it now accepts SVG with coordinates in scientific notation such as `3.14e-2`.
It fixes #870 (and #816 too?).

I added a test case, but I am afraid it may not be enough.
In particular, the behavior of the function might change to some extent especially for 'ill-formed' SVG paths.
Please let me know if you have good test cases.

Thank  you.