### PR TITLE
Fix: set stroke and fill properly in PFont.getShape

### DIFF
--- a/core/src/processing/core/PFont.java
+++ b/core/src/processing/core/PFont.java
@@ -740,7 +740,7 @@ public class PFont implements PConstants {
     // six element array received from the Java2D path iterator
     float[] iterPoints = new float[6];
     // array passed to createGlyphVector
-    char[] textArray = new char[] { ch };
+    char[] textArray = { ch };
 
     //Graphics2D graphics = (Graphics2D) this.getGraphics();
     //FontRenderContext frc = graphics.getFontRenderContext();
@@ -755,16 +755,17 @@ public class PFont implements PConstants {
       shp.getPathIterator(null, detail);  // convert to line segments
 
     int contours = 0;
+    s.beginShape();
+    s.noStroke();
+    s.fill(0);
     while (!iter.isDone()) {
       int type = iter.currentSegment(iterPoints);
       switch (type) {
       case PathIterator.SEG_MOVETO:   // 1 point (2 vars) in textPoints
-        if (contours == 0) {
-          s.beginShape();
-        } else {
+        if (contours > 0) {
           s.beginContour();
         }
-        contours++;
+        ++contours;
         s.vertex(iterPoints[0], iterPoints[1]);
         break;
 


### PR DESCRIPTION
Currently, `PFont.getShape` returns an instance of `PShape` which renders nothing.
This is because fill and storke are not properly set in the construction of the shape.
The commit fixes the issue by calling `PShape.noStroke()` and `PShape.fill(0)` at the begining of the construction.

Test code:
```processing
import java.awt.Font;
import java.util.stream.IntStream;

PFont symbols;
PShape[] symbolShapes;

void setup() {
  size(512, 512);
  
  symbols = createFont("winjs-symbols.ttf", 32);
  Font font = (Font) symbols.getNative();
  final int[] codes = IntStream.range(0, 0x10000).filter(font::canDisplay).toArray();
  symbolShapes = new PShape[codes.length];
  for(int i = 0; i < codes.length; ++i) {
    symbolShapes[i] = symbols.getShape((char) codes[i]);
    symbolShapes[i].width=32;
    symbolShapes[i].height=32;
  }
}

void draw() {
  background(#AABBCC);
  for(int i = 0; i < symbolShapes.length; ++i) {
    int x = i % 16;
    int y = i / 16;
    symbolShapes[i].setFill(#0000FF);
    shape(symbolShapes[i], 32 * x + 4, 32 * y + 36, 24, 24);
  }
}
```
`winjs-symbols.ttf` can be downladed [here](https://github.com/microsoft/fonts/raw/1259517be73038f430d6e52fd130dd714bef6804/Symbols/winjs-symbols.ttf).