### PR TITLE
Make PShapeOpenGL.setFill(int,int) always update tessellated vertices

### DIFF
--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -2005,12 +2005,12 @@ public class PShapeOpenGL extends PShape {
     }
 
     if (image == null) {
-      if (root.tessUpdate) {
+      inGeo.colors[index] = PGL.javaToNativeARGB(fill);
+      if (shapeCreated && tessellated && hasPolys) {
         int tessIdx = firstPolyVertex + index;
         tessGeo.polyColors[tessIdx] = PGL.javaToNativeARGB(fill);
         root.setModifiedPolyColors(tessIdx, tessIdx);
       } else {
-        inGeo.colors[index] = PGL.javaToNativeARGB(fill);
         markForTessellation();
       }
     }
@@ -2101,12 +2101,12 @@ public class PShapeOpenGL extends PShape {
     }
 
     if (image != null) {
-      if (root.tessUpdate) {
+      inGeo.colors[index] = PGL.javaToNativeARGB(tint);
+      if (shapeCreated && tessellated && hasPolys) {
         int tessIdx = firstPolyVertex + index;
         tessGeo.polyColors[tessIdx] = PGL.javaToNativeARGB(tint);
         root.setModifiedPolyColors(tessIdx, tessIdx);
       } else {
-        inGeo.colors[index] = PGL.javaToNativeARGB(tint);
         markForTessellation();
       }
     }


### PR DESCRIPTION
Fixes #900 (and #677 too).

`PShapeOpenGL` provides "Tessellation update mode" `beginTessellation()` and `endTessellation()`.
The current implementation of `PShapeOpenGL.setFill(int,int)` does the following:
- if it is in "Tessellation update mode" (`root.tessUpdate == true`), it updates the color associated with tessellated vertices;
- otherwise, it updates the "raw" data `InGeometry` and set "tessellation required" flag with `markForTessellation()`.

The problem is that once the shape is tessellated, the tessellation doesn't seem to be performed again even after markForTessellation().
Another concern is that the behavior described above is inconsistent with `PShape.OpenGL.setFill(int)` overload, which does not care about "Tessellation update mode" and updates tessellated vertices anyway.

This PR makes `PShapeOpenGL.setFill(int,int)` behaves like the other overloads.
As a result, it also ignores "Tessellation update mode".
I am not 100% sure it is safe, since `beginTessellation()` and `endTessellation()` look doing a lot of stuff.
In particular, I think this change should be tested for the cases where tessellation creates new vertices.
Since I do not know the tessellation process in detail, such test cases are really appreciated.