### PR TITLE
Add new preference option 'console.head_padding'

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2293,19 +2293,9 @@ public abstract class Editor extends JFrame implements RunnerListener {
     internalCloseRunner();
     statusEmpty();
 
-    int headPadding;
-
-    try {
-      headPadding = Preferences.getInteger("console.head_padding");
-    } catch (NullPointerException e) {
-      // We need to handle this exception to take care of old versions of
-      // preference files, i.e., "defaults.txt" and "preferences.txt" which
-      // may not have the attribute 'console.head_padding'.
-      headPadding = 10;
-    }
-
     // Do this to advance/clear the terminal window / dos prompt / etc.
     // This may be useful especially when 'console.auto_clear' is false.
+    int headPadding = Preferences.getInteger("console.head_padding");
     for (int i = 0; i < headPadding; i++) console.message("\n", false);
 
     // clear the console on each run, unless the user doesn't want to

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2293,8 +2293,22 @@ public abstract class Editor extends JFrame implements RunnerListener {
     internalCloseRunner();
     statusEmpty();
 
-    // do this to advance/clear the terminal window / dos prompt / etc
-    for (int i = 0; i < 10; i++) System.out.println();
+    int headPadding;
+
+    try {
+      headPadding = Preferences.getInteger("console.head_padding");
+    } catch (NullPointerException e) {
+      // We need to handle this exception to take care of old versions of
+      // preference files, i.e., "defaults.txt" and "preferences.txt" which
+      // may not have the attribute 'console.head_padding'.
+      headPadding = 10;
+    }
+
+    // Do this to advance/clear the terminal window / dos prompt / etc.
+    // This may be useful especially when 'console.auto_clear' is false.
+    // TODO: use `console.message()` instead of `System.out.println()`?
+    // i.e. for (int i = 0; i < headPadding; i++) console.message("\n", false);
+    for (int i = 0; i < headPadding; i++) System.out.println();
 
     // clear the console on each run, unless the user doesn't want to
     if (Preferences.getBoolean("console.auto_clear")) {

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2306,9 +2306,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
     // Do this to advance/clear the terminal window / dos prompt / etc.
     // This may be useful especially when 'console.auto_clear' is false.
-    // TODO: use `console.message()` instead of `System.out.println()`?
-    // i.e. for (int i = 0; i < headPadding; i++) console.message("\n", false);
-    for (int i = 0; i < headPadding; i++) System.out.println();
+    for (int i = 0; i < headPadding; i++) console.message("\n", false);
 
     // clear the console on each run, unless the user doesn't want to
     if (Preferences.getBoolean("console.auto_clear")) {

--- a/build/shared/lib/defaults.txt
+++ b/build/shared/lib/defaults.txt
@@ -165,8 +165,16 @@ console.font.size = 12
 # number of lines to show by default
 console.lines = 4
 
-# set to false to disable automatically clearing the console
+# Number of blank lines to advance/clear console.
+# Note that those lines are also printed in the terminal when
+# Processing is executed there.
+# Setting to 0 stops this behavior.
+console.head_padding = 10
+
+# Set to false to disable automatically clearing the console
 # each time 'run' is hit
+# If one sets it to false, one may also want to set 'console.head_padding'
+# to a positive number to separate outputs from different runs.
 console.auto_clear = true
 
 # number of days of history to keep around before cleaning


### PR DESCRIPTION
The PR adds `console.head_padding` preference option to configure blank lines printed in terminal/console in each time a sketch is run.

The background is found in #911.

Making the change, I originally planned to only add an option for backward compatibility.
However, I finally decided to rewrite the code for "padding by blank lines" using `EditConsole.message` instead of `System.out.println` to stop printing them in the terminal.
The reasons why I think this is safe are as follows:
1. First of all, the change only affects the IDE (i.e. `processing`) and not command-line mode (i.e. `processing-java`).
Hence, it would not affect the final products of any projects using Processing either.
2. **Windows**: after investigation, I realized that the blank lines does not affect Windows terminals (i.e. command prompt or PowerShell) probably because of launch4j.
So, maybe it would not seriously break backward compatibility in Windows if the blank lines are removed.
3. **Linux**: `processing` is run as a background process, so any outputs can mess up the terminal.
Moreover, since the blank lines are likely the only outputs from IDE (NOTE: `print`/`println` does not print to terminal from IDE), so I think nobody rely on the behavior.

Unfortunately, I have not tested on MacOS and cannot since I don't have any machines.
It would be great if someone tests the change of behavior on MacOS and gives comments.

I also note that, in spite of my comments in #911, the head padding may be useful when `console.auto_clear` option is set to `false`.
For example, the following code prints `HelloHelloHello` without line breaks if you run it three times with `console.auto_clear = false` and `console.head_padding = 0` on your `preferences.txt`:
```processing
print("Hello");
```


I wonder if `console.auto_clear` and the new option `console.head_padding` are worth putting in the preference dialog.
In some situations, keeping console outputs may help debugging, but currently nobody knows the option.