### PR TITLE
Make the specification for the runner more specific

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           # compiling for arm32 needs a self-hosted runner on Raspi OS (32-bit)
-          - os: self-hosted
+          - os: [self-hosted, linux, ARM]
             os_prefix: linux
             arch: arm
           - os: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           # compiling for arm32 needs a self-hosted runner on Raspi OS (32-bit)
-          - os: self-hosted
+          - os: [self-hosted, linux, ARM]
             os_prefix: linux
             arch: arm
           - os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         include:
           # compiling for arm32 needs a self-hosted runner on Raspi OS (32-bit)
-          - os: self-hosted
+          - os: [self-hosted, linux, ARM]
             os_prefix: linux
             arch: arm
           - os: ubuntu-latest


### PR DESCRIPTION
Right now we have arm64 and arm32 runners and sometimes they get mixed up because the label is not specific enough causing builds to fail 

[skip ci]