### PR TITLE
Set Layout in Java2D

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -422,7 +422,9 @@ public class PSurfaceAWT extends PSurfaceNone {
       //frame.setVisible(true);  // re-add native resources
     }
     */
-    frame.setLayout(null);
+    // Solves #862 - Grey/White bar on right side of sketches
+    frame.setLayout(new BoxLayout(frame.getContentPane(), BoxLayout.Y_AXIS));
+    frame.pack();
 
     // Need to pass back our new sketchWidth/Height here, because it may have
     // been overridden by numbers we calculated above if fullScreen and/or

--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -33,8 +33,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 
 import processing.core.PApplet;
 import processing.core.PConstants;

--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -421,9 +421,7 @@ public class PSurfaceAWT extends PSurfaceNone {
       //frame.setVisible(true);  // re-add native resources
     }
     */
-    // Solves #862 - Grey/White bar on right side of sketches
-    frame.setLayout(new BoxLayout(frame.getContentPane(), BoxLayout.Y_AXIS));
-    frame.pack();
+    frame.setLayout(null);
 
     // Need to pass back our new sketchWidth/Height here, because it may have
     // been overridden by numbers we calculated above if fullScreen and/or
@@ -1022,6 +1020,9 @@ public class PSurfaceAWT extends PSurfaceNone {
             //sketch.postWindowMoved(x - currentInsets.left, y - currentInsets.top);
             sketch.postWindowMoved(x, y);  // presumably user wants drawing area
           }
+        }else{
+          // Solves #862 - Grey/White bar on right side of sketches
+          setFrameSize();
         }
       }
 


### PR DESCRIPTION
Setting the layout to `null` generates an issue on KDE Plasma. Not entirely sure what the underlying issue is but changing it to a `BoxLayout` solves the issue. Needs testing on platforms other than macOS and Manjaro KDE Plasma

Closes #862 