### PR TITLE
Fix for NullPointerException thrown in `PApplet.dequeueWindowEvents()`

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -9663,7 +9663,7 @@ public class PApplet implements PConstants {
 
   // WINDOW METHODS
 
-  Map<String, Integer> windowEventQueue = new ConcurrentHashMap<>();
+  Map<String, WindowEventValuePairs> windowEventQueue = new ConcurrentHashMap<>();
 
 
   public void windowTitle(String title) {
@@ -9683,8 +9683,7 @@ public class PApplet implements PConstants {
    * only the notification that the resize has happened.
    */
   public void postWindowResized(int newWidth, int newHeight) {
-    windowEventQueue.put("w", newWidth);
-    windowEventQueue.put("h", newHeight);
+    windowEventQueue.put("wh", new WindowEventValuePairs(newWidth, newHeight));
   }
 
 
@@ -9724,8 +9723,7 @@ public class PApplet implements PConstants {
       frameMoved(newX, newY);
     }
 
-    windowEventQueue.put("x", newX);
-    windowEventQueue.put("y", newY);
+    windowEventQueue.put("xy", new WindowEventValuePairs(newX, newY));
   }
 
 
@@ -9734,21 +9732,28 @@ public class PApplet implements PConstants {
 
 
   private void dequeueWindowEvents() {
-    if (windowEventQueue.containsKey("x")) {
-      windowX = windowEventQueue.remove("x");
-      windowY = windowEventQueue.remove("y");
+    if (windowEventQueue.containsKey("xy")) {
+      WindowEventValuePairs xy = windowEventQueue.remove("xy");
+      windowX = xy.num1;
+      windowY = xy.num2;
       windowMoved();
     }
-    if (windowEventQueue.containsKey("w")) {
-      // these should already match width/height
-      //windowResized(windowEventQueue.remove("w"),
-      //              windowEventQueue.remove("h"));
-      windowEventQueue.remove("w");
-      windowEventQueue.remove("h");
+    if (windowEventQueue.containsKey("wh")) {
+      WindowEventValuePairs wh = windowEventQueue.remove("wh");
       windowResized();
     }
   }
 
+  protected class WindowEventValuePairs {
+
+    public int num1;
+    public int num2;
+
+    public WindowEventValuePairs(int num1, int num2) {
+      this.num1 = num1;
+      this.num2 = num2;
+    }
+  }
 
   /**
    * Scale the sketch as if it fits this specific width and height.


### PR DESCRIPTION
Here is a fix for #918.

When the window is moved or resized, the new location or size values will be stored as a pair in the `windowEventQueue` map. This ensures that there are no race conditions if one value has been added but the other has not.

The exception I saw when I opened #918 is probably very rare and would be hard to reproduce. Nevertheless, we can review the code change and verify that the necessary functionality still works. You can test window move and resize events with the following code:

```java
void setup() {
  size(200, 200, JAVA2D);
  windowResizable(true);
  windowMove(100, 100);
}

void draw() {
}

void windowResized() {
  println("new size", width, height);
}

void windowMoved() {
  println("new location", windowX, windowY);
}

void keyPressed() {
  windowResize(200, 200);
  windowMove(100, 100);
}
```

It also works with the `P2D` renderer.
