### PR TITLE
Fix Sketch Window Resizing Issues with Java2D Renderer on Windows

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -227,7 +227,7 @@ public class PSurfaceAWT extends PSurfaceNone {
   }
 
 
-  synchronized protected void render() {
+  protected void render() {
     if (canvas.isDisplayable() &&
         graphics.image != null) {
       if (canvas.getBufferStrategy() == null) {


### PR DESCRIPTION
Seems like the synchronised was there for an older approach to rendering. Made redundant by the BufferStrategy in 2015. 

Now it causes issues on windows if you resize the window too quickly

Closes #931 