### PR TITLE
Updated dependency locations to somewhere more stable 🤞

### DIFF
--- a/app/build.xml
+++ b/app/build.xml
@@ -4,14 +4,14 @@
   <!-- Current version of Ant that works with Processing -->
   <!-- (Cannot use ant.version as the name of the property
        because that conflicts with the built-in variable) -->
-  <property name="ant.version.num" value="1.10.12" />
+  <property name="ant.version.num" value="1.10.15" />
   <!-- the .zip file to be downloaded -->
   <property name="ant.zip" value="apache-ant-${ant.version.num}-bin.zip" />
 
   <!-- TODO implement a fallback URL that points to a location
        on download.processing.org so it's available forever. -->
   <property name="ant.url"
-            value="https://archive.apache.org/dist/ant/binaries/${ant.zip}" />
+            value="https://dlcdn.apache.org//ant/binaries/${ant.zip}" />
 
   <fileset id="ant.files" dir="lib">
     <include name="ant.jar" />

--- a/java/libraries/svg/build.xml
+++ b/java/libraries/svg/build.xml
@@ -3,7 +3,7 @@
 
   <property name="core.library.jar" location="../../../core/library/core.jar" />
 
-  <property name="batik.version" value="1.14" />
+  <property name="batik.version" value="1.18" />
   <!-- the .zip file to be downloaded -->
   <property name="batik.zip" value="batik-bin-${batik.version}.zip" />
   <!-- the .jar file that we need from the download -->
@@ -13,7 +13,7 @@
 
   <!-- URL for the version of Batik currently supported by this library. -->
   <property name="batik.url"
-            value="https://archive.apache.org/dist/xmlgraphics/batik/binaries/${batik.zip}" />
+            value="https://dlcdn.apache.org//xmlgraphics/batik/binaries/${batik.zip}" />
 
   <!-- Storing a "local" copy in case the original link goes dead. When updating
        releases, please upload the new version to download.processing.org. -->


### PR DESCRIPTION
The `ant` and `batik` dependencies kept failing because they were being downloaded from the Apache archive (which they themselves labeled as unstable) so I switched the download to the official sources.