### PR TITLE
Fix #825 - Showing wrong errors' line numbers for .java files

### DIFF
--- a/java/src/processing/mode/java/ErrorChecker.java
+++ b/java/src/processing/mode/java/ErrorChecker.java
@@ -194,14 +194,29 @@ public class ErrorChecker {
 
 
   static private JavaProblem convertIProblem(IProblem iproblem, PreprocSketch ps) {
-    SketchInterval in = ps.mapJavaToSketch(iproblem);
-    if (in != SketchInterval.BEFORE_START) {
-      String badCode = ps.getPdeCode(in);
-      int line = ps.tabOffsetToTabLine(in.tabIndex, in.startTabOffset);
-      JavaProblem p = JavaProblem.fromIProblem(iproblem, in.tabIndex, line, badCode);
+    String originalFileName = new String(iproblem.getOriginatingFileName());
+    boolean isJavaTab = ps.isJavaTab(originalFileName);
+
+    // Java tabs' content isn't stored in a sketch's combined source code file,
+    // so they are processed differently
+    if (!isJavaTab) {
+      SketchInterval in = ps.mapJavaToSketch(iproblem);
+      if (in != SketchInterval.BEFORE_START) {
+        String badCode = ps.getPdeCode(in);
+        int line = ps.tabOffsetToTabLine(in.tabIndex, in.startTabOffset);
+        JavaProblem p = JavaProblem.fromIProblem(iproblem, in.tabIndex, line, badCode);
+        p.setPDEOffsets(0, -1);
+        return p;
+      }
+    } else {
+      int tabIndex = ps.getJavaTabIndex(originalFileName);
+      int line = iproblem.getSourceLineNumber() - 1;
+
+      JavaProblem p =  JavaProblem.fromIProblem(iproblem, tabIndex, line, "");
       p.setPDEOffsets(0, -1);
       return p;
     }
+
     return null;
   }
 

--- a/java/src/processing/mode/java/PreprocSketch.java
+++ b/java/src/processing/mode/java/PreprocSketch.java
@@ -72,6 +72,16 @@ public class PreprocSketch {
   }
 
 
+  public boolean isJavaTab(String fileName) {
+    return javaFileMapping.containsKey(fileName);
+  }
+
+
+  public int getJavaTabIndex(String fileName) {
+    return javaFileMapping.get(fileName);
+  }
+
+
   public SketchInterval mapJavaToSketch(IProblem iproblem) {
     String originalFile = new String(iproblem.getOriginatingFileName());
     boolean isJavaTab = javaFileMapping.containsKey(originalFile);


### PR DESCRIPTION
Using PreprocSketch.mapJavaToSketch result for processing .java files is incorrect, as a sketch's combined source code file does not include code from .java tabs.

As far as I can see, there is a similar issue with showing variables usage, so I would suggest this solution as a temporary one.

Closes #825 (originally at https://github.com/benfry/processing4/issues/825) 