### PR TITLE
Fixes #896 : Fixed getVertexCount() method issue of giving output 0 for GROUP shapes

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -2335,13 +2335,13 @@ public class PShape implements PConstants {
   }
 
   /**
-   * The <b>getVertexCount()</b> method returns the number of vertices that
-   * make up a <b>PShape</b>. In the above example, the value 4 is returned by the
+   * The <b>getVertexCount()</b> method returns the number of vertices (with an option to count children by passing true as boolean parameter to method call) that
+   * make up a <b>PShape</b>. By default, it does not count child vertices for GROUP shapes. To include child vertices, pass <b>true</b> as a boolean parameter. In the above example, the value 4 is returned by the
    * <b>getVertexCount()</b> method because 4 vertices are defined in
    * <b>setup()</b>.
    *
    * @webref pshape:method
-   * @webBrief Returns the total number of vertices as an int
+   * @webBrief Returns the total number of vertices as an int with an option to count children Vertex for GROUP Shapes
    * @see PShape#getVertex(int)
    * @see PShape#setVertex(int, float, float)
    */

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -2345,8 +2345,18 @@ public class PShape implements PConstants {
    * @see PShape#getVertex(int)
    * @see PShape#setVertex(int, float, float)
    */
+  public int getVertexCount(boolean includeChildren) {
+    if(!includeChildren && family == GROUP){
+      PGraphics.showWarning(NO_VERTICES_ERROR);
+    }
+    else if (family == PRIMITIVE) {
+      PGraphics.showWarning(NO_VERTICES_ERROR);
+    }
+    return vertexCount;
+  }
+
   public int getVertexCount() {
-    if (family == PRIMITIVE) {
+    if(family == GROUP || family == PRIMITIVE){
       PGraphics.showWarning(NO_VERTICES_ERROR);
     }
     return vertexCount;

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -2346,7 +2346,7 @@ public class PShape implements PConstants {
    * @see PShape#setVertex(int, float, float)
    */
   public int getVertexCount() {
-    if (family == GROUP || family == PRIMITIVE) {
+    if (family == PRIMITIVE) {
       PGraphics.showWarning(NO_VERTICES_ERROR);
     }
     return vertexCount;

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -1635,17 +1635,23 @@ public class PShapeOpenGL extends PShape {
 
   @Override
   public int getVertexCount() {
-    if (family == GROUP) return 0; // Group shapes don't have vertices
-    else {
+     int count = 0;
+    // If the shape is a group, recursively count the vertices of its children
+    if (family == GROUP) {
+      // Iterate through all the child shapes and count their vertices
+      for (int i = 0; i < getChildCount(); i++) {
+        count += getChild(i).getVertexCount();  // Recursive call to get the vertex count of child shapes
+      }
+    } else {
       if (root.tessUpdate) {
         if (root.tessKind == TRIANGLES) {
-          return lastPolyVertex - firstPolyVertex + 1;
+          count += lastPolyVertex - firstPolyVertex + 1;
         } else if (root.tessKind == LINES) {
-          return lastLineVertex - firstLineVertex + 1;
+          count += lastLineVertex - firstLineVertex + 1;
         } else if (root.tessKind == POINTS) {
-          return lastPointVertex - firstPointVertex + 1;
+          count += lastPointVertex - firstPointVertex + 1;
         } else {
-          return 0;
+          count += 0; // Handle other cases
         }
       } else {
         if (family == PRIMITIVE || family == PATH) {
@@ -1653,10 +1659,12 @@ public class PShapeOpenGL extends PShape {
           // tessellation
           updateTessellation();
         }
-        return inGeo.vertexCount;
+        count += inGeo.vertexCount;
       }
     }
+    return count;
   }
+
 
 
   @Override

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -1632,15 +1632,23 @@ public class PShapeOpenGL extends PShape {
 
   // Setters/getters of individual vertices
 
-
+  //for taking the default value as false , so user don't have to explicitly enter false
+  // if user don't want to include children vertex count
   @Override
   public int getVertexCount() {
+    return getVertexCount(false);  // Calls the main method with default false
+  }
+  @Override
+  public int getVertexCount(boolean includeChildren) {
      int count = 0;
     // If the shape is a group, recursively count the vertices of its children
     if (family == GROUP) {
+      if(!includeChildren){
+        return 0;
+      }
       // Iterate through all the child shapes and count their vertices
       for (int i = 0; i < getChildCount(); i++) {
-        count += getChild(i).getVertexCount();  // Recursive call to get the vertex count of child shapes
+        count += getChild(i).getVertexCount(true);  // Recursive call to get the vertex count of child shapes
       }
     } else {
       if (root.tessUpdate) {
@@ -1664,7 +1672,6 @@ public class PShapeOpenGL extends PShape {
     }
     return count;
   }
-
 
 
   @Override


### PR DESCRIPTION
Fixed the issue of getting output 0 from `getVertexCount()` method for `GROUP` shapes by Updating the `getVertexCount()` method in `PShape` class and `PShapeOpenGL` class

Closes #896 