### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For licensing information about the Processing website see the [processing-websi
 
 Copyright (c) 2015-now The Processing Foundation
 
-## All Contributors List
+## Contributors
 
 Add yourself to the contributors list [here](https://github.com/processing/processing4-carbon-aug-19/issues/839)!
 


### PR DESCRIPTION
The [all-contributors specification](https://allcontributors.org/docs/en/specification) explicitly says:

> A "Contributors" section in a prominent site of the project repository documentation that includes a list of all project contributors

Editing it back to `Contributors`.

[skip ci]