### PR TITLE
Fixed unexpected Y-axis translation when using ```ortho()``` and ```resetMatrix()```

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -4481,7 +4481,7 @@ public class PGraphicsOpenGL extends PGraphics {
 
     // The minus sign is needed to invert the Y axis.
     projection.set(x,  0, 0, tx,
-                   0, -y, 0, ty,
+                   0, -y, 0, -ty,
                    0,  0, z, tz,
                    0,  0, 0,  1);
 


### PR DESCRIPTION
This issue was a simple one pending so I thought to pick it up and fix it, implementing the suggested approach in issue description.

Fixes #891 

Before:
![image](https://github.com/user-attachments/assets/3cdc1675-4134-4f04-821f-3e16889cb06f)

After:
![image](https://github.com/user-attachments/assets/1642f315-7ba1-405c-9d62-893e40280c6e)

This is just a quick patch, as mentioned in additional comments a better long term solution would be refactoring the rendering pipeline to handle the Y-axis inversion.