### PR TITLE
Patch for keyPressed true with no keys pressed after specific sequence of ```SHIFT``` or ```CTRL```

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2630,13 +2630,15 @@ public class PApplet implements PConstants {
 
     switch (event.getAction()) {
       case KeyEvent.PRESS -> {
-        Long hash = ((long) keyCode << Character.SIZE) | key;
+        Long hash = (long) keyCode;
         if (!pressedKeys.contains(hash)) pressedKeys.add(hash);
         keyPressed = true;
         keyPressed(keyEvent);
       }
       case KeyEvent.RELEASE -> {
-        pressedKeys.remove(((long) keyCode << Character.SIZE) | key);
+        Long hash = (long) keyCode;
+        pressedKeys.remove(hash);
+
         keyPressed = !pressedKeys.isEmpty();
         keyReleased(keyEvent);
       }


### PR DESCRIPTION
The issue was that earlier we were using a hash for registering keys. For example, when someone pressed Ctrl and then A, the combination Ctrl+A got registered, and when they released Ctrl and then A, the Ctrl+A combination remained registered because it had a specific hash that was not released upon releasing both keys. That is why I removed the hash and am now directly registering the key.

However, I'm not sure why we were using a hash in the first place. Is there any specific reason? If yes, then I can change this approach.

Fixes #779 