### PR TITLE
[feat] Introduce Move Lines Feature, Fix Selection Bug on macOS, and Update JavaDoc

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -844,7 +844,6 @@ public abstract class Editor extends JFrame implements RunnerListener {
     editMenuUpdatable.add(action);
     menu.add(item);
 
-
     // Update copy/cut state on selection/de-selection
     menu.addMenuListener(new MenuListener() {
       // UndoAction and RedoAction do this for themselves.
@@ -1889,7 +1888,6 @@ public abstract class Editor extends JFrame implements RunnerListener {
   }
 
 
-
   public void handleIndent() {
     handleIndentOutdent(true);
   }
@@ -1943,6 +1941,8 @@ public abstract class Editor extends JFrame implements RunnerListener {
     stopCompoundEdit();
     sketch.setModified(true);
   }
+
+  
   /**
    * Moves the selected lines up or down in the text editor.
    *
@@ -2045,6 +2045,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
       SwingUtilities.invokeLater(() -> textarea.setCaretPosition(newCaretPos));
     }
 }
+
 
   static public boolean checkParen(char[] array, int index, int stop) {
     while (index < stop) {

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -349,6 +349,29 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
     // Enable window resizing (which allows for full screen button)
     setResizable(true);
+
+    {
+      // Move Lines Keyboard Shortcut (Alt + Arrow Up/Down)
+      KeyStroke moveUpKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.ALT_DOWN_MASK);
+      final String MOVE_UP_ACTION_KEY = "moveLinesUp";
+      textarea.getInputMap(JComponent.WHEN_FOCUSED).put(moveUpKeyStroke, MOVE_UP_ACTION_KEY);
+      textarea.getActionMap().put(MOVE_UP_ACTION_KEY, new AbstractAction() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          handleMoveLines(true);
+        }
+      });
+
+      KeyStroke moveDownKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.ALT_DOWN_MASK);
+      final String MOVE_DOWN_ACTION_KEY = "moveLinesDown";
+      textarea.getInputMap(JComponent.WHEN_FOCUSED).put(moveDownKeyStroke, MOVE_DOWN_ACTION_KEY);
+      textarea.getActionMap().put(MOVE_DOWN_ACTION_KEY, new AbstractAction() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          handleMoveLines(false);
+        }
+      });
+    }
   }
 
 
@@ -820,14 +843,6 @@ public abstract class Editor extends JFrame implements RunnerListener {
     item = Toolkit.newJMenuItem(action = new SelectionForFindAction(), 'E');
     editMenuUpdatable.add(action);
     menu.add(item);
-
-    item = new JMenuItem("Move Selected Lines Up");
-    item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.ALT_DOWN_MASK));
-    item.addActionListener(e -> handleMoveLines(true));
-
-    item = new JMenuItem("Move Selected Lines Down");
-    item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.ALT_DOWN_MASK));
-    item.addActionListener(e -> handleMoveLines(false));
 
 
     // Update copy/cut state on selection/de-selection

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -824,12 +824,10 @@ public abstract class Editor extends JFrame implements RunnerListener {
     item = new JMenuItem("Move Selected Lines Up");
     item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.ALT_DOWN_MASK));
     item.addActionListener(e -> handleMoveLines(true));
-    menu.add(item);
 
     item = new JMenuItem("Move Selected Lines Down");
     item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.ALT_DOWN_MASK));
     item.addActionListener(e -> handleMoveLines(false));
-    menu.add(item);
 
 
     // Update copy/cut state on selection/de-selection

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1936,6 +1936,8 @@ public abstract class Editor extends JFrame implements RunnerListener {
    * <p>If {@code moveUp} is true, the selected lines are moved up. If false, they move down.</p>
    * <p>This method ensures proper selection updates and handles edge cases like moving
    * the first or last line.</p>
+   * <p>This operation is undo/redoable, allowing the user to revert the action using
+   * {@code Ctrl/Cmd + Z} (Undo) and redo with {@code Ctrl/Cmd + Y} (Redo).</p>
    *
    * @param moveUp {@code true} to move the selection up, {@code false} to move it down.
    */
@@ -2005,7 +2007,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
               : textarea.getLineStopOffset(stopLine); // Prevent out-of-bounds
     }
 
-    textarea.select(newSelectionStart, newSelectionEnd);
+    SwingUtilities.invokeLater(() -> textarea.select(newSelectionStart, newSelectionEnd));
     stopCompoundEdit();
   }
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1959,7 +1959,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     startCompoundEdit();
     boolean isSelected = false;
 
-    if(textarea.isSelectionActive())
+    if (textarea.isSelectionActive())
       isSelected = true;
 
     int caretPos = textarea.getCaretPosition();
@@ -2031,7 +2031,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     }
     stopCompoundEdit();
 
-    if(isSelected)
+    if (isSelected)
       SwingUtilities.invokeLater(() -> {
         textarea.select(newSelectionStart, newSelectionEnd-1);
       });

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1937,7 +1937,8 @@ public abstract class Editor extends JFrame implements RunnerListener {
    * <p>This method ensures proper selection updates and handles edge cases like moving
    * the first or last line.</p>
    * <p>This operation is undo/redoable, allowing the user to revert the action using
-   * {@code Ctrl/Cmd + Z} (Undo) and redo with {@code Ctrl/Cmd + Y} (Redo).</p>
+   * {@code Ctrl/Cmd + Z} (Undo). Redo functionality is available through the
+   * keybinding {@code Ctrl/Cmd + Z} on Windows/Linux and {@code Shift + Cmd + Z} on macOS.</p>
    *
    * @param moveUp {@code true} to move the selection up, {@code false} to move it down.
    */


### PR DESCRIPTION
## Feature Overview
This PR closes issue #953 and introduces the **Move Lines** feature, allowing users to move selected lines up or down in the editor. The feature ensures:  
- Proper selection behavior after moving lines.  
- Undo (`Ctrl + Z`) and redo (`Ctrl + Y` on **Windows/Linux** and `Shift + Cmd + Z` on **macOS**) functionality.  
- Clear documentation for expected behavior.  

## Fixes & Improvements  

### **Fixed Selection Bug on macOS**  
- Previously, moving lines down on macOS caused the cursor to jump to the end of enclosing braces instead of maintaining selection.  
- The fix ensures selection updates correctly by wrapping them in `SwingUtilities.invokeLater()`, ensuring execution on the Swing event dispatch thread.  
- The issue did not occur on Windows, but testing confirmed consistent behavior across both platforms.  

### **Updated JavaDoc for Users**  
- Clarified that redo on macOS is `Shift + Cmd + Z`, not `Cmd + Y`.  
- Improved documentation to provide clear guidance on the move lines feature.  

## Testing 
- **Linux:** Tested on a **Manjaro System** and confirmed working. A video demonstration is included.  
- **macOS:** Tested on a **macOS Catalina System** and confirmed working. A video demonstration and Screenshots are included.   
- **Windows:** Tested on a **Windows 11 System** and confirmed working. A video demonstration is included.  

## Media 
### Linux Video Demonstration:
https://github.com/user-attachments/assets/152c880a-33b5-4b92-9884-f63bc97426ac

### macOS Video Demonstration and Screenshots:
#### Video Demonstration
https://github.com/user-attachments/assets/8e968251-640b-4151-ac50-bbae2e540480

#### Screenshots
![Before macOS](https://github.com/user-attachments/assets/8d3fa583-fc31-40e2-a8db-0d31bf09d82c)
![After macOS](https://github.com/user-attachments/assets/11ea80e6-75f4-4350-899c-79c07b9c78cd)


### Windows Video Demonstration: 

https://github.com/user-attachments/assets/8656237f-80fb-4e47-b8ec-9817ad890ca6


### JavaDoc for the `handleMoveLines(boolean moveUp)` method
![image](https://github.com/user-attachments/assets/fabec4a8-ca15-41ad-a2af-763d27afdd32)
 

### **Next Steps**  
This PR introduces a new feature while ensuring cross-platform reliability. Further review and feedback are welcome. 

---