### PR TITLE
Fixed blur filter throwing exception for too large values relative to image

### DIFF
--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -1057,6 +1057,9 @@ public class PImage implements PConstants, Cloneable {
    * [toxi 050728]
    */
   protected void buildBlurKernel(float r) {
+    float maxRadius = Math.min(width, height) / 2.0f;
+    float maxR = maxRadius / 3.5f;
+    r = Math.min(r, maxR);
     int radius = (int) (r * 3.5f);
     if (radius < 1) radius = 1;
     if (radius > 248) radius = 248;
@@ -1083,6 +1086,9 @@ public class PImage implements PConstants, Cloneable {
     }
   }
 
+  private int safeDivide(int numerator, int denominator) {
+    return denominator == 0 ? numerator : numerator / denominator;
+  }
 
   protected void blurAlpha(float r) {
     int sum, cb;
@@ -1115,7 +1121,7 @@ public class PImage implements PConstants, Cloneable {
           read++;
         }
         ri = yi + x;
-        b2[ri] = cb / sum;
+        b2[ri] = safeDivide(cb, sum);
       }
       yi += pixelWidth;
     }
@@ -1146,7 +1152,7 @@ public class PImage implements PConstants, Cloneable {
           ri++;
           read += pixelWidth;
         }
-        pixels[x+yi] = (cb/sum);
+        pixels[x+yi] = safeDivide(cb, sum);
       }
       yi += pixelWidth;
       ymi += pixelWidth;
@@ -1191,9 +1197,9 @@ public class PImage implements PConstants, Cloneable {
           read++;
         }
         ri = yi + x;
-        r2[ri] = cr / sum;
-        g2[ri] = cg / sum;
-        b2[ri] = cb / sum;
+        r2[ri] = safeDivide(cr, sum);
+        g2[ri] = safeDivide(cg, sum);
+        b2[ri] = safeDivide(cb, sum);
       }
       yi += pixelWidth;
     }
@@ -1228,7 +1234,7 @@ public class PImage implements PConstants, Cloneable {
           ri++;
           read += pixelWidth;
         }
-        pixels[x+yi] = 0xff000000 | (cr/sum)<<16 | (cg/sum)<<8 | (cb/sum);
+        pixels[x+yi] = 0xff000000 | (safeDivide(cr, sum))<<16 | (safeDivide(cg, sum))<<8 | (safeDivide(cb, sum));
       }
       yi += pixelWidth;
       ymi += pixelWidth;
@@ -1276,10 +1282,10 @@ public class PImage implements PConstants, Cloneable {
           read++;
         }
         ri = yi + x;
-        a2[ri] = ca / sum;
-        r2[ri] = cr / sum;
-        g2[ri] = cg / sum;
-        b2[ri] = cb / sum;
+        a2[ri] = safeDivide(ca, sum);
+        r2[ri] = safeDivide(cr, sum);
+        g2[ri] = safeDivide(cg, sum);
+        b2[ri] = safeDivide(cb, sum);
       }
       yi += pixelWidth;
     }
@@ -1315,7 +1321,7 @@ public class PImage implements PConstants, Cloneable {
           ri++;
           read += pixelWidth;
         }
-        pixels[x+yi] = (ca/sum)<<24 | (cr/sum)<<16 | (cg/sum)<<8 | (cb/sum);
+        pixels[x+yi] = (safeDivide(ca, sum))<<24 | (safeDivide(cr, sum))<<16 | (safeDivide(cg, sum))<<8 | (safeDivide(cb, sum));
       }
       yi += pixelWidth;
       ymi += pixelWidth;


### PR DESCRIPTION
In this PR I've clamped radius to ensure we calculate maximum allowed blur in case of too large values relative to the image
I've also added a check for sum to make it 1 if it is 0 because it can be still zero in some cases even after clamping.

I tested it for the code provided in the issue and it works without crashing:
```Processing
void setup() {
  size(100, 100, P3D);
}

void draw() {
  background(0);
  ellipse(50, 50, 80, 80);
  filter(BLUR, 29);
}
```

Output:
![image](https://github.com/user-attachments/assets/6d337e02-d4ab-4afa-b424-90ba4d542442)

Their can be other approaches too, like throwing a meaningful error for the users.


This PR fixes #723 