### PR TITLE
Padding fix for Windows & Linux

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -208,7 +208,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     Box box = Box.createVerticalBox();
     Box upper = Box.createVerticalBox();
 
-    if(SystemInfo.isMacFullWindowContentSupported) {
+    if(Platform.isMacOS() && SystemInfo.isMacFullWindowContentSupported) {
       getRootPane().putClientProperty( "apple.awt.fullWindowContent", true );
       getRootPane().putClientProperty( "apple.awt.transparentTitleBar", true );
 


### PR DESCRIPTION
Who would've thought `SystemInfo.isMacFullWindowContentSupported` would be true on Windows and Linux