### PR TITLE
Fix JDK requirement for debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -353,6 +353,7 @@ tasks.register<Download>("includeJdk") {
             into(composeResources(""))
         }
     }
+    finalizedBy("prepareAppResources")
 }
 tasks.register<Copy>("includeSharedAssets"){
     from("../build/shared/")
@@ -510,7 +511,6 @@ afterEvaluate {
         dependsOn(
             "includeCore",
             "includeJavaMode",
-            "includeJdk",
             "includeSharedAssets",
             "includeProcessingExamples",
             "includeProcessingWebsiteExamples",
@@ -538,7 +538,7 @@ afterEvaluate {
         }
     }
     tasks.named("createDistributable").configure {
-        dependsOn("signResources")
+        dependsOn("signResources", "includeJdk")
         finalizedBy("setExecutablePermissions")
     }
 }


### PR DESCRIPTION
As noticed in #985, having to re-download the JDK for just a debug build is not necessary, this change makes the JDK download only required for distributable builds