### PR TITLE
Add Smooth Scrolling to the PDE

### DIFF
--- a/app/src/processing/app/syntax/TextAreaPainter.java
+++ b/app/src/processing/app/syntax/TextAreaPainter.java
@@ -25,6 +25,7 @@ import javax.swing.ToolTipManager;
 import javax.swing.text.*;
 import javax.swing.JComponent;
 
+import processing.app.Messages;
 import processing.app.Preferences;
 import processing.app.syntax.im.CompositionTextPainter;
 
@@ -230,6 +231,10 @@ public class TextAreaPainter extends JComponent implements TabExpander {
     int height = fontMetrics.getHeight();
     int firstLine = textArea.getFirstLine();
     int firstInvalid = firstLine + clipRect.y / height;
+
+    double verticalSmoothOffset = (textArea.getVerticalSmoothScrollPosition() - firstLine) * fontMetrics.getHeight();
+    g2.translate(0, -verticalSmoothOffset);
+
     // Because the clipRect height is usually an even multiple
     // of the font height, we subtract 1 from it, otherwise one
     // too many lines will always be painted.


### PR DESCRIPTION
In an effort to make the PDE more modern feeling, I realised this morning that a big part of the issue is that the scrolling updates per line, not with the scroll wheel (mostly with smooth scrolling on macOS).

This change will make scrolling in the PDE fractional, meaning you can scroll 1/3 or a line or less if you want. It also increases the re-rendering frequency of scrolling updates.

## Demo 



https://github.com/user-attachments/assets/aa895496-95a6-4eab-9168-1c576c5be18e



## Left to do

- [ ] Fix an issue where the gutter is not drawn if you scroll fast enough
- [ ] Fix an issue where some of the redrawing is not correct
- [ ] Fix an issue where the user can overscroll the sketch (although this could also be a feature)
- [ ] Horizontal smooth scrolling
- [ ] Fix Scrolling by scrollbar
- [ ] Implement dampening on Windows and Linux?

