### PR TITLE
Update docs for setHeading

### DIFF
--- a/core/src/processing/core/PVector.java
+++ b/core/src/processing/core/PVector.java
@@ -848,13 +848,15 @@ public class PVector implements Serializable {
 
   /**
    *
-   * Calculate the angle of rotation for this vector (only 2D vectors)
-   *
+   * Calculate the vector's direction, that is, the angle this vector makes
+   * with the positive X axis (only 2D vectors)
+   * 
    *
    * @webref pvector:method
    * @usage web_application
-   * @return the angle of rotation
+   * @return the direction of the vector (angle with positive X axis)
    * @webBrief  Calculate the angle of rotation for this vector
+   * @see PVector#setHeading()
    */
   public float heading() {
     float angle = (float) Math.atan2(y, x);
@@ -867,7 +869,18 @@ public class PVector implements Serializable {
     return heading();
   }
 
-
+  /**
+   *
+   * Sets the angle this vector makes with the positive X axis (only 2D vectors)
+   * This is equivalent to changing the vector's direction to the given value.
+   *
+   * @webref pvector:method
+   * @usage web_application
+   * @param angle the direction of the resultant vector
+   * @return this vector, rotated to have the given direction
+   * @webBrief  Set the direction for this vector
+   * @see PVector#heading()
+   */
   public PVector setHeading(float angle) {
     float m = mag();
     x = (float) (m * Math.cos(angle));

--- a/java/keywords.txt
+++ b/java/keywords.txt
@@ -503,6 +503,7 @@ size	FUNCTION2	FloatList_size_
 sort	FUNCTION2	FloatList_sort_
 sortReverse	FUNCTION2	FloatList_sortReverse_
 sub	FUNCTION2	FloatList_sub_
+toArray	FUNCTION2	FloatList_toArray_
 floor	FUNCTION1	floor_
 focused	KEYWORD4	focused
 frameCount	KEYWORD4	frameCount
@@ -559,6 +560,7 @@ size	FUNCTION2	IntList_size_
 sort	FUNCTION2	IntList_sort_
 sortReverse	FUNCTION2	IntList_sortReverse_
 sub	FUNCTION2	IntList_sub_
+toArray	FUNCTION2	IntList_toArray_
 join	FUNCTION1	join_
 JSONArray	KEYWORD5	JSONArray
 append	FUNCTION2	JSONArray_append_
@@ -579,6 +581,8 @@ setJSONArray	FUNCTION2	JSONArray_setJSONArray_
 setJSONObject	FUNCTION2	JSONArray_setJSONObject_
 setString	FUNCTION2	JSONArray_setString_
 size	FUNCTION2	JSONArray_size_
+toIntArray	FUNCTION2	JSONArray_toIntArray_
+toStringArray	FUNCTION2	JSONArray_toStringArray_
 JSONObject	KEYWORD5	JSONObject
 getBoolean	FUNCTION2	JSONObject_getBoolean_
 getFloat	FUNCTION2	JSONObject_getFloat_
@@ -848,6 +852,7 @@ shuffle	FUNCTION2	StringList_shuffle_
 size	FUNCTION2	StringList_size_
 sort	FUNCTION2	StringList_sort_
 sortReverse	FUNCTION2	StringList_sortReverse_
+toArray	FUNCTION2	StringList_toArray_
 upper	FUNCTION2	StringList_upper_
 stroke	FUNCTION1	stroke_
 strokeCap	FUNCTION1	strokeCap_
@@ -912,6 +917,13 @@ unbinary	FUNCTION1	unbinary_
 unhex	FUNCTION1	unhex_
 updatePixels	FUNCTION1	updatePixels_
 vertex	FUNCTION1	vertex_
+windowMove	FUNCTION1	windowMove_
+windowMoved	FUNCTION1	windowMoved_
+windowRatio	FUNCTION1	windowRatio_
+windowResizable	FUNCTION1	windowResizable_
+windowResize	FUNCTION1	windowResize_
+windowResized	FUNCTION1	windowResized_
+windowTitle	FUNCTION1	windowTitle_
 XML	KEYWORD5	XML
 addChild	FUNCTION2	XML_addChild_
 format	FUNCTION2	XML_format_

--- a/java/keywords.txt
+++ b/java/keywords.txt
@@ -751,6 +751,7 @@ random2D	FUNCTION2	PVector_random2D_
 random3D	FUNCTION2	PVector_random3D_
 rotate	FUNCTION2	PVector_rotate_
 set	FUNCTION2	PVector_set_
+setHeading	FUNCTION2	PVector_setHeading_
 setMag	FUNCTION2	PVector_setMag_
 sub	FUNCTION2	PVector_sub_
 quad	FUNCTION1	quad_


### PR DESCRIPTION
Resolves #472

Adds JavaDoc for `PVector#setHeading()` and the associated `keywords.txt` entry, generated using the instruction at https://github.com/processing/processing-website?tab=readme-ov-file#keywordstxt. This allows the Syntax Highlighting and `Open Content Reference` context menu item to work.

(Note: `Open Content Reference` will open missing page until https://github.com/processing/processing-website/pull/621 is merged and properly deployed.)

(Note 2: Also updates the documentation for `PVector#heading()` to be more explanatory, inspired by https://p5js.org/reference/p5.Vector/heading, so that JSON might also require regeneration. (Done) )

Adds more missing keywords to the `keywords.txt` file. (Generated via keywords.txt update routine)