### PR TITLE
Fix a color issue on macOS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ compose.desktop {
                 entitlementsFile.set(file("macos/entitlements.plist"))
                 runtimeEntitlementsFile.set(file("macos/entitlements.plist"))
                 appStore = true
+                jvmArgs("-Dsun.java2d.metal=true")
             }
             windows{
                 iconFile = rootProject.file("build/windows/processing.ico")


### PR DESCRIPTION
On a Mac with an HDR display it would render colours incorrectly in the PDE

<img width="1728" alt="Screenshot 2025-03-26 at 16 50 14" src="https://github.com/user-attachments/assets/e44174c5-644e-404e-a03a-40ca6036847f" />
