### PR TITLE
Store where Processing is installed

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -166,6 +166,20 @@ public class Base {
   static private void createAndShowGUI(String[] args) {
     // these times are fairly negligible relative to Base.<init>
 //    long t1 = System.currentTimeMillis();
+    var preferences = java.util.prefs.Preferences.userRoot().node("org/processing/app");
+    var installLocations = new ArrayList<>(List.of(preferences.get("installLocations", "").split(",")));
+    var installLocation = System.getProperty("user.dir") + "^" + Base.getVersionName();
+
+    // Check if the installLocation is already in the list
+    if (!installLocations.contains(installLocation)) {
+      // Add the installLocation to the list
+      installLocations.add(installLocation);
+
+      // Save the updated list back to preferences
+      preferences.put("installLocations", String.join(",", installLocations));
+    }
+    // TODO: Cleanup old locations if no longer installed
+    // TODO: Cleanup old locations if current version is installed in the same location
 
     File versionFile = Platform.getContentFile("lib/version.txt");
     if (versionFile != null && versionFile.exists()) {


### PR DESCRIPTION
It has been clear to me for a while that third-party tools need a way to discover where Processing is installed.

The Java Preferences are not the best solution but they are the best documented and clear on how this would work and is a tool that we won't have to maintain.

- [ ] Add some documentation to the repo on how to read the Java preferences outside of Java
- [ ] Remove old install locations
- [ ] Remove duplicate install locations because version changed