### PR TITLE
Update PGraphics.java: fix typos in documentation

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -913,7 +913,7 @@ public class PApplet implements PConstants {
    * Processing Development Environment (PDE). For example, when
    * using the Eclipse code editor, it's necessary to use
    * <b>settings()</b> to define the <b>size()</b> and
-   * <b>smooth()</b> values for a sketch.</b>.
+   * <b>smooth()</b> values for a sketch.
    * <br /> <br />
    * The <b>settings()</b> method runs before the sketch has been
    * set up, so other Processing functions cannot be used at that

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -6252,7 +6252,7 @@ public class PGraphics extends PImage implements PConstants {
    * <br /><br />
    * The style information controlled by the following functions are included
    * in the style:
-   * <b>fill()<b>, <b>stroke()</b>, <b>tint()</b>, <b>strokeWeight()</b>, <b>strokeCap()</b>,<b>strokeJoin()</b>,
+   * <b>fill()</b>, <b>stroke()</b>, <b>tint()</b>, <b>strokeWeight()</b>, <b>strokeCap()</b>,<b>strokeJoin()</b>,
    * <b>imageMode()</b>, <b>rectMode()</b>, <b>ellipseMode()</b>, <b>shapeMode()</b>, <b>colorMode()</b>,
    * <b>textAlign()</b>, <b>textFont()</b>, <b>textMode()</b>, <b>textSize()</b>, <b>textLeading()</b>,
    * <b>emissive()</b>, <b>specular()</b>, <b>shininess()</b>, <b>ambient()</b>

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -3559,8 +3559,8 @@ public class PGraphics extends PImage implements PConstants {
 
   /**
    * Calculates the tangent of a point on a curve. There's a good definition
-   * of <em><a href="http://en.wikipedia.org/wiki/Tangent"
-   * target="new">tangent</em> on Wikipedia</a>.
+   * of <a href="http://en.wikipedia.org/wiki/Tangent"
+   * target="new"><em>tangent</em> on Wikipedia</a>.
    *
    * <h3>Advanced</h3>
    * Code thanks to Dave Bollinger (Bug #715)

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -2496,7 +2496,7 @@ public class PGraphics extends PImage implements PConstants {
    * <br />
    * Using point() with strokeWeight(1) or smaller may draw nothing to the screen,
    * depending on the graphics settings of the computer. Workarounds include
-   * setting the pixel using <b>set()</s> or drawing the point using either
+   * setting the pixel using <b>set()</b> or drawing the point using either
    * <b>circle()</b> or <b>square()</b>.
    *
    * @webref shape:2d primitives
@@ -6439,7 +6439,7 @@ public class PGraphics extends PImage implements PConstants {
    * <br />
    * Using point() with strokeWeight(1) or smaller may draw nothing to the screen,
    * depending on the graphics settings of the computer. Workarounds include
-   * setting the pixel using <b>set()</s> or drawing the point using either
+   * setting the pixel using <b>set()</b> or drawing the point using either
    * <b>circle()</b> or <b>square()</b>.
    *
    * @webref shape:attributes


### PR DESCRIPTION
how it looks:
![image](https://github.com/user-attachments/assets/7cf3b533-8b43-49f1-88d0-6125abd7d68c)
how its supposed to look like:
![image](https://github.com/user-attachments/assets/b332f9e6-63e7-4b47-aef2-93a57e5f31f5)
