### PR TITLE
Move populateSketchbookMenu to a separate thread

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1942,18 +1942,20 @@ public class Base {
 
 
   public void populateSketchbookMenu(JMenu menu) {
-    boolean found = false;
-    try {
-      found = addSketches(menu, sketchbookFolder);
-    } catch (Exception e) {
-      Messages.showWarning("Sketchbook Menu Error",
-                           "An error occurred while trying to list the sketchbook.", e);
-    }
-    if (!found) {
-      JMenuItem empty = new JMenuItem(Language.text("menu.file.sketchbook.empty"));
-      empty.setEnabled(false);
-      menu.add(empty);
-    }
+    new Thread(() -> {
+      boolean found = false;
+      try {
+        found = addSketches(menu, sketchbookFolder);
+      } catch (Exception e) {
+        Messages.showWarning("Sketchbook Menu Error",
+                "An error occurred while trying to list the sketchbook.", e);
+      }
+      if (!found) {
+        JMenuItem empty = new JMenuItem(Language.text("menu.file.sketchbook.empty"));
+        empty.setEnabled(false);
+        menu.add(empty);
+      }
+    }).start();
   }
 
 
@@ -1964,8 +1966,14 @@ public class Base {
    * sketch should open in a new window.
    */
   protected boolean addSketches(JMenu menu, File folder) {
+    Messages.log("scanning " + folder.getAbsolutePath());
     // skip .DS_Store files, etc. (this shouldn't actually be necessary)
     if (!folder.isDirectory()) {
+      return false;
+    }
+
+    // Don't look inside the 'android' folders in the sketchbook
+    if (folder.getName().equals("android")) {
       return false;
     }
 
@@ -2054,12 +2062,18 @@ public class Base {
    */
   public boolean addSketches(DefaultMutableTreeNode node, File folder,
                              boolean examples) throws IOException {
+    Messages.log("scanning " + folder.getAbsolutePath());
     // skip .DS_Store files, etc. (this shouldn't actually be necessary)
     if (!folder.isDirectory()) {
       return false;
     }
 
     final String folderName = folder.getName();
+
+    // Don't look inside the 'android' folders in the sketchbook
+    if (folderName.equals("android")) {
+      return false;
+    }
 
     // Don't look inside the 'libraries' folders in the sketchbook
     if (folderName.equals("libraries")) {


### PR DESCRIPTION
We were getting reports of Processing being slow to start, we diagnosed it to having a lot of folders within the sketchbook. The problem arises from Processing indexing all the folders recursively on the UI thread.

While this has been a known issue—documented in the [troubleshooting guide](https://github.com/processing/processing4/wiki/Troubleshooting#windows)—we noticed it's made significantly worse in cases where users have multiple Android SDKs installed inside their sketchbook; each SDK contains a large number of subfolders, making Processing hang for a long time on startup or when switching mode.

This PR moves the scanning to a separate thread. It also skips scanning the `android` folder if present in the sketchbook.

These changes should help alleviate some of the slowdown but it’s only a quick fix. Long term, we probably need a better approach, avoiding recursion and maybe caching the results.

Fixes #1036 
Related to #897?