### PR TITLE
Setup a Command Line Interface 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ sourceSets{
 
 compose.desktop {
     application {
-        mainClass = "processing.app.ui.Start"
+        mainClass = "processing.app.ProcessingKt"
 
         jvmArgs(*listOf(
             Pair("processing.version", rootProject.version),
@@ -97,6 +97,7 @@ compose.desktop {
 
 dependencies {
     implementation(project(":core"))
+    runtimeOnly(project(":java"))
 
     implementation(libs.flatlaf)
 
@@ -121,6 +122,8 @@ dependencies {
     testImplementation(libs.mockitoKotlin)
     testImplementation(libs.junitJupiter)
     testImplementation(libs.junitJupiterParams)
+
+    implementation("com.github.ajalt.clikt:clikt:5.0.2")
 }
 
 tasks.test {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,7 +123,7 @@ dependencies {
     testImplementation(libs.junitJupiter)
     testImplementation(libs.junitJupiterParams)
 
-    implementation("com.github.ajalt.clikt:clikt:5.0.2")
+    implementation(libs.clikt)
 }
 
 tasks.test {

--- a/app/src/processing/app/Processing.kt
+++ b/app/src/processing/app/Processing.kt
@@ -1,0 +1,70 @@
+package processing.app
+
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
+import com.github.ajalt.clikt.command.main
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import processing.app.ui.Start
+
+// TODO: Allow Start to run on no args
+// TODO: Modify InstallCommander to use the new structure
+// TODO: Move dependency to gradle toml
+// TODO: Add the options/arguments for Base arguments
+class Processing(val args: Array<String>): SuspendingCliktCommand(name = "Processing"){
+    override suspend fun run() {
+        if(currentContext.invokedSubcommand == null){
+            Start.main(args)
+        }
+    }
+}
+
+suspend fun main(args: Array<String>) = Processing(args)
+    .subcommands(
+        LSP(args),
+        LegacyCLI(args)
+    )
+    .main(args)
+
+
+class LSP(val args: Array<String>): SuspendingCliktCommand("lsp"){
+    override fun help(context: Context) = "Start the Processing Language Server"
+    override suspend fun run(){
+        try {
+            // Indirect invocation since app does not depend on java mode
+            Class.forName("processing.mode.java.lsp.PdeLanguageServer")
+                .getMethod("main", Array<String>::class.java)
+                .invoke(null, *arrayOf<Any>(args))
+        } catch (e: Exception) {
+            throw InternalError("Failed to invoke main method", e)
+        }
+    }
+}
+
+class LegacyCLI(val args: Array<String>): SuspendingCliktCommand(name = "cli"){
+    override fun help(context: Context) = "Legacy processing-java command line interface"
+
+    val help by option("--help").flag()
+    val build by option("--build").flag()
+    val run by option("--run").flag()
+    val present by option("--present").flag()
+    val sketch: String? by option("--sketch")
+    val force by option("--force").flag()
+    val output: String? by option("--output")
+    val export by option("--export").flag()
+    val noJava by option("--no-java").flag()
+    val variant: String? by option("--variant")
+
+    override suspend fun run(){
+        val cliArgs = args.filter { it != "cli" }.toTypedArray()
+        try {
+            // Indirect invocation since app does not depend on java mode
+            Class.forName("processing.mode.java.Commander")
+                .getMethod("main", Array<String>::class.java)
+                .invoke(null, *arrayOf<Any>(cliArgs))
+        } catch (e: Exception) {
+            throw InternalError("Failed to invoke main method", e)
+        }
+    }
+}

--- a/app/src/processing/app/Processing.kt
+++ b/app/src/processing/app/Processing.kt
@@ -8,10 +8,15 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.help
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
 import processing.app.ui.Start
 
 class Processing: SuspendingCliktCommand("processing"){
+    val version by option("-v","--version")
+        .flag()
+        .help("Print version information")
+
     val sketches by argument()
         .multiple(default = emptyList())
         .help("Sketches to open")
@@ -19,6 +24,11 @@ class Processing: SuspendingCliktCommand("processing"){
     override fun help(context: Context) = "Start the Processing IDE"
     override val invokeWithoutSubcommand = true
     override suspend fun run() {
+        if(version){
+            println("processing-${Base.getVersionName()}-${Base.getRevision()}")
+            return
+        }
+
         val subcommand = currentContext.invokedSubcommand
         if (subcommand == null) {
             Start.main(sketches.toTypedArray())

--- a/app/src/processing/app/Processing.kt
+++ b/app/src/processing/app/Processing.kt
@@ -5,13 +5,16 @@ import com.github.ajalt.clikt.command.main
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.help
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import processing.app.ui.Start
 
 class Processing: SuspendingCliktCommand("processing"){
-    val sketches by argument().multiple(default = emptyList())
+    val sketches by argument()
+        .multiple(default = emptyList())
+        .help("Sketches to open")
 
     override fun help(context: Context) = "Start the Processing IDE"
     override val invokeWithoutSubcommand = true

--- a/core/examples/src/main/java/Basic.java
+++ b/core/examples/src/main/java/Basic.java
@@ -1,12 +1,25 @@
 import processing.core.PApplet;
 
+import java.io.IOException;
+
 public class Basic extends PApplet {
     public void settings(){
         size(500, 500);
+
+        try {
+            Runtime.getRuntime().exec("echo Hello World");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void draw(){
-        ellipse(width / 2f, height / 2f, 125f, 125f);
+        background(255);
+        fill(0);
+        ellipse(mouseX, mouseY, 125f, 125f);
+        println(frameRate);
+
+
     }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ lsp4j = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version = "0.22.0" }
 jsoup = { module = "org.jsoup:jsoup", version = "1.17.2" }
 markdown = { module = "com.mikepenz:multiplatform-markdown-renderer-m2", version = "0.31.0" }
 markdownJVM = { module = "com.mikepenz:multiplatform-markdown-renderer-jvm", version = "0.31.0" }
+clikt = { module = "com.github.ajalt.clikt:clikt", version = "5.0.2" }
 
 [plugins]
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }

--- a/java/src/processing/mode/java/lsp/PdeLanguageServer.java
+++ b/java/src/processing/mode/java/lsp/PdeLanguageServer.java
@@ -21,7 +21,7 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageClient;
 
 
-class PdeLanguageServer implements LanguageServer, LanguageClientAware {
+public class PdeLanguageServer implements LanguageServer, LanguageClientAware {
   Map<File, PdeAdapter> adapters = new HashMap<>();
   LanguageClient client = null;
   PdeTextDocumentService textDocumentService = new PdeTextDocumentService(this);


### PR DESCRIPTION
This pull request will add command line arguments to the main Processing binary. Removing the need to publish separate binaries for additional functionality.

This will deprecate `processing-java` in favour of `processing cli` on linux.

Currently added functionality:
- `cli` Legacy hook for users of `processing-java`
- `lsp` Start the Language Server (for VSCode and Intellij)
-  More to come, feel free to suggest more tools that could be added. 

Fixes #1045 and Fixes #1047 

<img width="976" alt="Screenshot 2025-04-18 at 17 43 42" src="https://github.com/user-attachments/assets/66376c2e-6fea-4df0-8b39-88b8181f2189" />
