### PR TITLE
Add `removable-media` as a Snap Plug

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -240,6 +240,7 @@ tasks.register("generateSnapConfiguration"){
           - network
           - opengl
           - home
+          - removable-media
     
     parts:
       processing:


### PR DESCRIPTION
Fixes #1051 

I referenced the Firefox snap configuration and they also defined the `removable-media` plug so it makes sense to me that we should also support it.