### PR TITLE
Added missing module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,7 +59,7 @@ compose.desktop {
         ).map { "-D${it.first}=${it.second}" }.toTypedArray())
 
         nativeDistributions{
-            modules("jdk.jdi", "java.compiler", "jdk.accessibility", "java.management.rmi")
+            modules("jdk.jdi", "java.compiler", "jdk.accessibility", "java.management.rmi", "java.scripting")
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Processing"
 


### PR DESCRIPTION
p5.js uses the java.scripting module which was removed in the Gradle transition, this PR fixes that

Fixes #1055 