### PR TITLE
Add the ability to choose the interpolation mode when resizing an image

### DIFF
--- a/core/src/processing/awt/ShimAWT.java
+++ b/core/src/processing/awt/ShimAWT.java
@@ -237,7 +237,7 @@ public class ShimAWT implements PConstants {
   }
 
 
-  static public void resizeImage(PImage img, int w, int h) {  // ignore
+  static public void resizeImage(PImage img, int w, int h, int interpolationMode) {  // ignore
     if (w <= 0 && h <= 0) {
       throw new IllegalArgumentException("width or height must be > 0 for resize");
     }
@@ -251,7 +251,8 @@ public class ShimAWT implements PConstants {
     }
 
     BufferedImage bimg =
-      shrinkImage((BufferedImage) img.getNative(), w*img.pixelDensity, h*img.pixelDensity);
+      shrinkImage((BufferedImage) img.getNative(), w*img.pixelDensity,
+              h*img.pixelDensity, interpolationMode);
 
     PImage temp = new PImageAWT(bimg);
     img.pixelWidth = temp.width;
@@ -274,7 +275,8 @@ public class ShimAWT implements PConstants {
   // plus a fix to deal with an infinite loop if images are expanded.
   // https://github.com/processing/processing/issues/1501
   static private BufferedImage shrinkImage(BufferedImage img,
-                                           int targetWidth, int targetHeight) {
+                                           int targetWidth, int targetHeight,
+                                           int interpolationMode) {
     int type = (img.getTransparency() == Transparency.OPAQUE) ?
       BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
     BufferedImage outgoing = img;
@@ -313,8 +315,16 @@ public class ShimAWT implements PConstants {
         scratchImage = new BufferedImage(w, h, type);
         g2 = scratchImage.createGraphics();
       }
+      // convert the passed int value of interpolationMode to the object expected
+      // by setRenderingHint
+      Object interpolationModeValue = switch(interpolationMode) {
+        case 0 -> RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR;
+        //case 1 is the same as the default
+        case 2 -> RenderingHints.VALUE_INTERPOLATION_BICUBIC;
+        default -> RenderingHints.VALUE_INTERPOLATION_BILINEAR;
+      };
       g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-        RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+              interpolationModeValue);
       g2.drawImage(outgoing, 0, 0, w, h, 0, 0, prevW, prevH, null);
       prevW = w;
       prevH = h;

--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -483,6 +483,11 @@ public interface PConstants {
   int WAIT  = Cursor.WAIT_CURSOR;
 
 
+  // image interpolation modes
+  int NEAREST_NEIGHBOR = 0;
+  int BILINEAR = 1;
+  int BICUBIC = 2;
+
   // hints - hint values are positive for the alternate version,
   // negative of the same value returns to the normal/default state
 

--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -497,11 +497,37 @@ public class PImage implements PConstants, Cloneable {
    * @usage web_application
    * @param w the resized image width
    * @param h the resized image height
+   * @param interpolationMode the type of interpolation that should be used when resizing the image
+   * @see PImage#get(int, int, int, int)
+   */
+  public void resize(int w, int h,int interpolationMode) {  // ignore
+    //throw new RuntimeException("resize() not implemented for this PImage type");
+    ShimAWT.resizeImage(this, w, h, interpolationMode);
+  }
+
+  /**
+   *
+   * Resize the image to a new width and height. To make the image scale
+   * proportionally, use 0 as the value for the <b>wide</b> or <b>high</b>
+   * parameter. For instance, to make the width of an image 150 pixels, and
+   * change the height using the same proportion, use <b>resize(150, 0)</b>.<br />
+   * <br />
+   * Even though a PGraphics is technically a <b>PImage</b>, it is not possible to
+   * rescale the image data found in a <b>PGraphics</b>. (It's simply not possible
+   * to do this consistently across renderers: technically infeasible with
+   * P3D, or what would it even do with PDF?) If you want to resize <b>PGraphics</b>
+   * content, first get a copy of its image data using the <b>get()</b>
+   * method, and call <b>resize()</b> on the PImage that is returned.
+   *
+   * @webref pimage:method
+   * @webBrief Resize the image to a new width and height
+   * @usage web_application
+   * @param w the resized image width
+   * @param h the resized image height
    * @see PImage#get(int, int, int, int)
    */
   public void resize(int w, int h) {  // ignore
-    //throw new RuntimeException("resize() not implemented for this PImage type");
-    ShimAWT.resizeImage(this, w, h);
+    resize(w, h, 1);
   }
 
 

--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -527,7 +527,7 @@ public class PImage implements PConstants, Cloneable {
    * @see PImage#get(int, int, int, int)
    */
   public void resize(int w, int h) {  // ignore
-    resize(w, h, 1);
+    resize(w, h, PConstants.BILINEAR);
   }
 
 


### PR DESCRIPTION
Added the ability to choose witch interpolation mode to use when resizing an image.

To do this there is a new overload for PImage.resize() that takes 3 ints (width, height, interpolation mode) there are also 3 new PConstants for the mode they are: NEAREST_NEIGHBOR, BILINEAR, and BICUBIC. They have a value of 0 1 and 2 respectively.

This has been accomplished by utilizing the different interpolation modes provided by the java awt library that was already used for resizing images.