### PR TITLE
Terminate JVM of already running instances

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -324,6 +324,8 @@ public class Base {
 
 //      long t10 = System.currentTimeMillis();
 //      System.out.println("startup took " + (t2-t1) + " " + (t3-t2) + " " + (t4-t3) + " " + (t5-t4) + " " + (t6-t5) + " " + (t10-t6) + " ms");
+    } else {
+      System.exit(0);
     }
   }
 

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -251,7 +251,16 @@ public class Base {
 
 //    long t2 = System.currentTimeMillis();
 
-    if (DEBUG || !SingleInstance.alreadyRunning(args)) {
+    // boolean flag indicating whether to create new server instance or not
+    boolean createNewInstance = DEBUG || !SingleInstance.alreadyRunning(args);
+
+    // free up resources by terminating the JVM
+    if(!createNewInstance){
+      System.exit(0);
+      return;
+    }
+
+    if (createNewInstance) {
       // Set the look and feel before opening the window
       try {
         Platform.setLookAndFeel();
@@ -324,8 +333,6 @@ public class Base {
 
 //      long t10 = System.currentTimeMillis();
 //      System.out.println("startup took " + (t2-t1) + " " + (t3-t2) + " " + (t4-t3) + " " + (t5-t4) + " " + (t6-t5) + " " + (t10-t6) + " ms");
-    } else {
-      System.exit(0);
     }
   }
 


### PR DESCRIPTION
## Resolves #1066

## Changes 
added `System.exit(0)` 
**why?**
when new Processing instance opens, a client socket is instantiated and connected to the main server socket (initiated by the main instance), then the main instance handles opening the sketch
but what about the instance that created the socket in the first place? we didn't terminate it's JVM, so it remains consuming resources and doing pretty much nothing

## Tests
i validate the changes by trying to locally build multiple instances
everything works as expected, and these instances automatically exits
