### PR TITLE
Fix executable permissions within Snap

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -276,6 +276,7 @@ tasks.register("generateSnapConfiguration"){
         override-prime: |
           snapcraftctl prime
           rm -vf usr/lib/jvm/java-17-openjdk-*/lib/security/cacerts
+          chmod -R +x opt/processing/lib/app/resources/jdk
     """.trimIndent()
     dir.file("../snapcraft.yaml").asFile.writeText(content)
 }


### PR DESCRIPTION
In #1054 I removed the `chmod -R +x opt/processing/lib/app/resources/jdk-*` under the impression that my changes fixed the underlying issue making this action redundant. Seeing in #1074 and #1047 this turns out not to be the case. Further investigation on the best way to assure that we have a runnable JDK is necessary.

