### PR TITLE
Include Movie Maker build steps in Gradle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -423,6 +423,8 @@ tasks.register("includeProcessingResources"){
         "includeJavaModeResources",
         "renameWindres"
     )
+    // Include Legacy Movie Maker
+    dependsOn(project(":build:shared:tools:MovieMaker").tasks.named("build") )
     finalizedBy("signResources")
 }
 

--- a/build/shared/tools/MovieMaker/build.gradle.kts
+++ b/build/shared/tools/MovieMaker/build.gradle.kts
@@ -1,0 +1,1 @@
+ant.importBuild("build.xml")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,4 +11,5 @@ include(
     "java:libraries:pdf",
     "java:libraries:serial",
     "java:libraries:svg",
+    "build:shared:tools:MovieMaker",
 )


### PR DESCRIPTION
When transitioning to Gradle, the Movie Maker was not included in the build steps, this PR adds the Ant build steps required to allow the Movie Maker to be included again.

- [ ] Test if macOS still successfully signs since this will add new binaries to the build.