### PR TITLE
Update Batik

### DIFF
--- a/java/libraries/svg/build.xml
+++ b/java/libraries/svg/build.xml
@@ -3,7 +3,7 @@
 
   <property name="core.library.jar" location="../../../core/library/core.jar" />
 
-  <property name="batik.version" value="1.18" />
+  <property name="batik.version" value="1.19" />
   <!-- the .zip file to be downloaded -->
   <property name="batik.zip" value="batik-bin-${batik.version}.zip" />
   <!-- the .jar file that we need from the download -->


### PR DESCRIPTION
Apache deleted Batik 1.18 from the defined download location, updating to 1.19 🤞