### PR TITLE
incorrect uniform resolution

### DIFF
--- a/core/src/processing/opengl/PShader.java
+++ b/core/src/processing/opengl/PShader.java
@@ -1210,8 +1210,8 @@ public class PShader implements PConstants {
     }
 
     if (-1 < resolutionLoc) {
-      float w = currentPG.viewport.get(2);
-      float h = currentPG.viewport.get(3);
+      float w = currentPG.viewport.get(2) * currentPG.pixelDensity;
+      float h = currentPG.viewport.get(3) * currentPG.pixelDensity;
       setUniformValue(resolutionLoc, w, h);
     }
 


### PR DESCRIPTION
## Resolves #1063

## Changes
correctly set the uniform resolution to reflect the changes in pixelDensity

**Why?**

when pixelDensity is set to 2 either implicitly (starting from Processing 4.4.3 version) ,or when called when creating a sketch
the physical resolution (width and height) is doubled, but that isn't reflected on the `uniform resolution` (the rendering resolution)
so for example in `conway.glsl` this piece of code `vec2 position = ( gl_FragCoord.xy / resolution.xy );` results in inconsistent position (wrong scaling) because `uniform resolution` still uses the logical resolution specificed in `size()` function

**Tests**
i tested all shaders examples, and everything seems fine except for two examples
1. **deform**, mouseX and mouseY also isn't reflected the change of pixelDensity
a simple solution is to multiple mouseX and mouseY by pixelDensity to reflect the correct position

2. **DemoProjection** this one is missed up, but i think it's related to the code written in sketch not sure about that