### PR TITLE
feat: added parameters named in parameters function

### DIFF
--- a/java/src/processing/mode/java/lsp/PdeAdapter.java
+++ b/java/src/processing/mode/java/lsp/PdeAdapter.java
@@ -308,13 +308,13 @@ class PdeAdapter {
     item.setInsertTextFormat(InsertTextFormat.Snippet);
     
     CompletionItemKind kind = switch (c.getType()) {
-      case 0 -> CompletionItemKind.Class;      
-      case 1 -> CompletionItemKind.Constant;  
-      case 2 -> CompletionItemKind.Function;  
-      case 3 -> CompletionItemKind.Class;      
-      case 4 -> CompletionItemKind.Method;     
-      case 5 -> CompletionItemKind.Field;      
-      case 6 -> CompletionItemKind.Variable;
+      case 0 -> CompletionItemKind.Class;      // PREDEF_CLASS
+      case 1 -> CompletionItemKind.Constant;   // PREDEF_FIELD
+      case 2 -> CompletionItemKind.Function;   // PREDEF_METHOD
+      case 3 -> CompletionItemKind.Class;      // LOCAL_CLASS
+      case 4 -> CompletionItemKind.Method;     // LOCAL_METHOD
+      case 5 -> CompletionItemKind.Field;      // LOCAL_FIELD
+      case 6 -> CompletionItemKind.Variable;   // LOCAL_VARIABLE
       default -> throw new IllegalArgumentException("Unknown completion type: " + c.getType());
     };
     item.setKind(kind);


### PR DESCRIPTION
Added parameters  names in function signatures

Part of #1041 

Some examples
```
{
      "label": "fill",
      "kind": 3,
      "detail": "fill(r, g, b, a)",
      "insertText": "fill($1)",
      "insertTextFormat": 2
}
```

```
{
      "label": "background",
      "kind": 3,
      "detail": "background(x, y, width, height)",
      "insertText": "background($1)",
      "insertTextFormat": 2
}
```

```
    {
      "label": "copy",
      "kind": 3,
      "detail": "copy(sx, sy, sw, sh, dx, dy, dw, dh)",
      "insertText": "copy($1)",
      "insertTextFormat": 2
    }
```

