### PR TITLE
Fix setResizable(true) bug on Linux Mint

### DIFF
--- a/core/examples/src/main/java/Issue1003.java
+++ b/core/examples/src/main/java/Issue1003.java
@@ -16,12 +16,11 @@ public class Issue1003 extends PApplet {
     }
 
     public void draw(){
-//        ((PSurfaceAWT) surface).setResizable(true);
-
         background(frameCount % 255);
         line(0, 0, width, height);
         line(width, 0, 0, height);
     }
+
     public static void main(String[] passedArgs) {
         String[] appletArgs = new String[]{ Issue1003.class.getName()};
         if (passedArgs != null) {

--- a/core/examples/src/main/java/Issue1003.java
+++ b/core/examples/src/main/java/Issue1003.java
@@ -1,0 +1,34 @@
+import processing.core.PApplet;
+import processing.awt.PSurfaceAWT;
+
+// Reproduction of issue #1003
+// Resizeable causes crash on linux mint
+public class Issue1003 extends PApplet {
+
+    public void settings(){
+        size(200, 200);
+    }
+
+    public void setup() {
+        ((PSurfaceAWT) surface).setTitle("Hello world!");
+        ((PSurfaceAWT) surface).setResizable(true);
+//        surface.setLocation(100, 100);
+    }
+
+    public void draw(){
+//        ((PSurfaceAWT) surface).setResizable(true);
+
+        background(frameCount % 255);
+        line(0, 0, width, height);
+        line(width, 0, 0, height);
+    }
+    public static void main(String[] passedArgs) {
+        String[] appletArgs = new String[]{ Issue1003.class.getName()};
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+
+    }
+}

--- a/core/examples/src/main/java/Issue1003.java
+++ b/core/examples/src/main/java/Issue1003.java
@@ -10,9 +10,9 @@ public class Issue1003 extends PApplet {
     }
 
     public void setup() {
-        ((PSurfaceAWT) surface).setTitle("Hello world!");
-        ((PSurfaceAWT) surface).setResizable(true);
-//        surface.setLocation(100, 100);
+        surface.setTitle("Hello resize!");
+        surface.setResizable(true);
+        surface.setLocation(100, 100);
     }
 
     public void draw(){

--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -49,7 +49,7 @@ public class PSurfaceAWT extends PSurfaceNone {
   GraphicsDevice displayDevice;
 
   // used for canvas to determine whether resizable or not
-//  boolean resizable;  // default is false
+  boolean resizable;  // default is false
 
   // Internally, we know it's always a JFrame (not just a Frame)
 //  JFrame frame;
@@ -57,6 +57,7 @@ public class PSurfaceAWT extends PSurfaceNone {
   // In the past, AWT Frames caused some problems on Windows and Linux,
   // but those may not be a problem for our reworked PSurfaceAWT class.
   JFrame frame;
+  boolean frameSetupComplete;
 
   // Note that x and y may not be zero, depending on the display configuration
   Rectangle screenRect;
@@ -84,6 +85,8 @@ public class PSurfaceAWT extends PSurfaceNone {
   public PSurfaceAWT(PGraphics graphics) {
     //this.graphics = graphics;
     super(graphics);
+
+    this.resizable = false; // Default is false, can be changed with surface.setResizable()
 
     /*
     if (checkRetina()) {
@@ -196,8 +199,7 @@ public class PSurfaceAWT extends PSurfaceNone {
 
     @Override
     public Dimension getMaximumSize() {
-      //return resizable ? super.getMaximumSize() : getPreferredSize();
-      return frame.isResizable() ? super.getMaximumSize() : getPreferredSize();
+      return resizable ? super.getMaximumSize() : getPreferredSize();
     }
 
 
@@ -442,7 +444,12 @@ public class PSurfaceAWT extends PSurfaceNone {
 
     // disabling resize has to happen after pack() to avoid apparent Apple bug
     // https://github.com/processing/processing/issues/506
-    frame.setResizable(false);
+    // Must use this.resizable to avoid bug where value is set before initFrame is finished
+    // https://github.com/processing/processing4/issues/1003
+    System.out.println("Resizable in initFrame: " + this.resizable);
+//    setResizable(this.resizable);
+//    frame.setResizable(true);
+//    frame.setResizable(this.resizable);
 
     frame.addWindowListener(new WindowAdapter() {
       @Override
@@ -484,11 +491,18 @@ public class PSurfaceAWT extends PSurfaceNone {
   /** Set true if we want to resize things (default is not resizable) */
   @Override
   public void setResizable(boolean resizable) {
-    //this.resizable = resizable;  // really only used for canvas
+    this.resizable = resizable;  // we need to store this so if frame init is not complete then we know the value
 
+    System.out.println("Frame in setResizable:" + frame);
     if (frame != null) {
-      frame.setResizable(resizable);
+      frame.setResizable(this.resizable);
+      System.out.println("PSurfaceAWT.frame.resizable set to:" + frame.isResizable());
+//      frame.isValid();
+      frame.validate();
+      System.out.println("PSurfaceAWT.frame.isValid():" + frame.isValid());
     }
+
+    System.out.println("PSurfaceAWT.resizable set to:" + this.resizable);
   }
 
 

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -10148,10 +10148,6 @@ public class PApplet implements PConstants {
 
 
     sketch.showSurface();
-
-    surface.setResizable(false);
-
-
     sketch.startSurface();
 
   }

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -10145,8 +10145,15 @@ public class PApplet implements PConstants {
     }
     */
 
+
+
     sketch.showSurface();
+
+    surface.setResizable(false);
+
+
     sketch.startSurface();
+
   }
 
 

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -10145,11 +10145,8 @@ public class PApplet implements PConstants {
     }
     */
 
-
-
     sketch.showSurface();
     sketch.startSurface();
-
   }
 
 


### PR DESCRIPTION
Fixes #1003 

Tested this after a gradle clean. Ran it about 8-10 times to ensure it was working as expected.

![Screenshot from 2025-05-12 12-44-51](https://github.com/user-attachments/assets/6bb1e2fe-7b74-44c4-8f46-f5abf5e55ce1)


I hope the reasoning behind the change is explained in comments but it seems like for whatever reason sometimes the window manager doesn't like multiple calls to `frame.setResizable()`. Noticed in debugging that if I removed where we set it to `false` then it works as expected. So the solution ultimately was to dispose of the frame and recreate it. Also noticed that a previous section of code about Insets likely would be good to un-comment because I was noticing black bars around sketches occasionally and this block of code seems to solve that.

This pr is intended to be squash merged.