### PR TITLE
Migrate ant based `serial` library to Gradle

### DIFF
--- a/java/libraries/serial/build.gradle.kts
+++ b/java/libraries/serial/build.gradle.kts
@@ -27,7 +27,7 @@ tasks.register("checkCore") {
 }
 
 tasks.register<Jar>("buildSerial") {
-    dependsOn("compileSerial")
+    dependsOn("checkCore")
     archiveFileName.set("serial.jar")
     destinationDirectory.set(file("library"))
     from(sourceSets.main.get().output)

--- a/java/libraries/serial/build.gradle.kts
+++ b/java/libraries/serial/build.gradle.kts
@@ -1,1 +1,39 @@
-ant.importBuild("build.xml")
+plugins {
+    java
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+val coreJarPath = layout.projectDirectory.file("../../../core/library/core.jar")
+val jsscJarPath = layout.projectDirectory.file("library/jssc.jar")
+val binDir = layout.projectDirectory.dir("bin")
+val serialJarOutputDir = layout.projectDirectory.dir("library")
+
+dependencies {
+    implementation(files(coreJarPath))
+    implementation(files(jsscJarPath))
+}
+
+tasks.register("checkCore") {
+    doFirst {
+        if (!coreJarPath.asFile.exists()) {
+            throw GradleException("Missing core.jar at $coreJarPath. Please build the core module first.")
+        }
+    }
+}
+
+tasks.register<Jar>("buildSerial") {
+    dependsOn("compileSerial")
+    archiveFileName.set("serial.jar")
+    destinationDirectory.set(file("library"))
+    from(sourceSets.main.get().output)
+}
+
+tasks.named<Delete>("clean") {
+    delete(binDir)
+    delete(serialJarOutputDir.file("serial.jar"))
+}


### PR DESCRIPTION
### Description
Migrated the serial library from Ant-based `build.xml` to Gradle `build.gradle.kts`

 ### Resolve Issue

#1099 

### Changes 
 Migrate Ant-based `build.xml` with `build.gradle.kts` for java/libraries/serial

### Checklist
 Build succeeds using Gradle
 serial no longer relies on Ant


- `build.gradle.kts` creates `build` folder in `library/serial` by default contains `serial.jar`, even if define source outDir path explicitly
- If I deleted `build.xml`, the Branch Builds (Legacy) GitHub action failed as `build.xml` was not found

Although I was able to run the project and only commit the main Gradle file changes

Let me know if further adjustments are needed!