### PR TITLE
Add error check for pixelDensity in mask()

### DIFF
--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -840,7 +840,6 @@ public class PImage implements PConstants, Cloneable {
    */
   public void mask(PImage img) {
     img.loadPixels();
-    this.loadPixels();
     if (this.pixelWidth != img.pixelWidth || this.pixelHeight != img.pixelHeight) {
       if (this.pixelDensity != img.pixelDensity) {
         throw new IllegalArgumentException("mask() requires the mask image to have the same pixel size after adjusting for pixelDensity.");

--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -840,6 +840,15 @@ public class PImage implements PConstants, Cloneable {
    */
   public void mask(PImage img) {
     img.loadPixels();
+    this.loadPixels();
+    if (this.pixelWidth != img.pixelWidth || this.pixelHeight != img.pixelHeight) {
+      if (this.pixelDensity != img.pixelDensity) {
+        throw new IllegalArgumentException("mask() requires the mask image to have the same pixel size after adjusting for pixelDensity.");
+      }
+      else if (this.width != img.width || this.height != img.height) {
+        throw new IllegalArgumentException("mask() requires the mask image to have the same width and height.");
+      }
+    }
     mask(img.pixels);
   }
 


### PR DESCRIPTION
Resolves: [#1065](https://github.com/processing/processing4/issues/1065)

Changes:
Add an error check for the mask() function in PImage.java to ensure both pixelWidth and pixelHeight of both imgs are matched.

Tests:
When pixel sizes don't match due to density difference, it will show an error line like below
<img width="702" alt="image" src="https://github.com/user-attachments/assets/6cdfbe95-b4dd-49b2-8df9-3ea852191794" />

When density doesn't match but underlying pixel size matches:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/1b01bd37-ad15-4991-b4fc-8dc6bf8061d1" />
