### PR TITLE
Fix reflection invocation of PdeLanguageServer

### DIFF
--- a/app/src/processing/app/Processing.kt
+++ b/app/src/processing/app/Processing.kt
@@ -52,7 +52,7 @@ class LSP: SuspendingCliktCommand("lsp"){
             // Indirect invocation since app does not depend on java mode
             Class.forName("processing.mode.java.lsp.PdeLanguageServer")
                 .getMethod("main", Array<String>::class.java)
-                .invoke(null, *arrayOf<Any>(emptyList<String>()))
+                .invoke(null, arrayOf<String>())
         } catch (e: Exception) {
             throw InternalError("Failed to invoke main method", e)
         }


### PR DESCRIPTION
Fixed argument type mismatch when invoking the PdeLanguageServer main method via reflection.

Changed from using spread operator with a list wrapper to passing a properly typed String array directly.

This resolves the IllegalArgumentException thrown during language server initialization.

```
Exception in thread "main" java.lang.InternalError: Failed to invoke main method
	at processing.app.LSP.run(Processing.kt:57)
	at com.github.ajalt.clikt.command.CoreSuspendingCliktCommandKt.parse(CoreSuspendingCliktCommand.kt:68)
	at com.github.ajalt.clikt.command.CoreSuspendingCliktCommandKt.main(CoreSuspendingCliktCommand.kt:39)
	at com.github.ajalt.clikt.command.CoreSuspendingCliktCommandKt.main(CoreSuspendingCliktCommand.kt:51)
	at processing.app.ProcessingKt.main(Processing.kt:45)
	at processing.app.ProcessingKt$main$2.invoke(Processing.kt)
	at processing.app.ProcessingKt$main$2.invoke(Processing.kt)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt$createCoroutineUnintercepted$$inlined$createCoroutineFromSuspendFunction$IntrinsicsKt__IntrinsicsJvmKt$1.invokeSuspend(IntrinsicsJvm.kt:223)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:115)
	at kotlin.coroutines.jvm.internal.RunSuspendKt.runSuspend(RunSuspend.kt:19)
	at processing.app.ProcessingKt.main(Processing.kt)
Caused by: java.lang.IllegalArgumentException: argument type mismatch
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at processing.app.LSP.run(Processing.kt:55)
	... 11 more
```