### PR TITLE
fixes error highlighting when selecting an error in another tab

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2736,6 +2736,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     }
 
     int tabIndex = p.getTabIndex();
+    sketch.setCurrentCode(tabIndex);  // so we are looking at the right offsets below
     int lineNumber = p.getLineNumber();
     int lineStart = textarea.getLineStartOffset(lineNumber);
     int lineEnd = textarea.getLineStopOffset(lineNumber);


### PR DESCRIPTION
Fixes #1112 

Current code finds start/end of highlight by finding char offsets based on the error's given line number; however, it's looking at the visible tab to do so, making the highlighting go wonky if you're selecting an error in a tab you don't have open yet.

Added one line to switch active tab before we find the char offsets.