### PR TITLE
Fix library class version error

### DIFF
--- a/java/src/processing/mode/java/runner/Runner.java
+++ b/java/src/processing/mode/java/runner/Runner.java
@@ -775,9 +775,9 @@ public class Runner implements MessageConsumer {
 
     } else if (exceptionClass.equals("java.lang.UnsupportedClassVersionError")) {
       listener.statusError("UnsupportedClassVersionError: A library is using code compiled with an unsupported version of Java.");
-      err.println("This version of Processing only supports libraries and JAR files compiled for Java 1.8 or earlier.");
-      err.println("A library used by this sketch was compiled for Java 1.9 or later, ");
-      err.println("and needs to be recompiled to be compatible with Java 1.8.");
+      err.println("This version of Processing only supports libraries and JAR files compiled for Java 17 or earlier.");
+      err.println("A library used by this sketch was compiled for Java 18 or later, ");
+      err.println("and needs to be recompiled to be compatible with Java 17.");
 
     } else if (exceptionClass.equals("java.lang.NoSuchMethodError") ||
                exceptionClass.equals("java.lang.NoSuchFieldError")) {

--- a/java/src/processing/mode/java/runner/Runner.java
+++ b/java/src/processing/mode/java/runner/Runner.java
@@ -774,10 +774,11 @@ public class Runner implements MessageConsumer {
       err.println("and your code should be rewritten in a more efficient manner.");
 
     } else if (exceptionClass.equals("java.lang.UnsupportedClassVersionError")) {
+      int javaVersion = Runtime.version().feature();
       listener.statusError("UnsupportedClassVersionError: A library is using code compiled with an unsupported version of Java.");
-      err.println("This version of Processing only supports libraries and JAR files compiled for Java 17 or earlier.");
-      err.println("A library used by this sketch was compiled for Java 18 or later, ");
-      err.println("and needs to be recompiled to be compatible with Java 17.");
+      err.println("This version of Processing only supports libraries and JAR files compiled for Java " + javaVersion + " or earlier.");
+      err.println("A library used by this sketch was compiled for Java " + (javaVersion + 1) + " or later, ");
+      err.println("and needs to be recompiled to be compatible with Java " + javaVersion + ".");
 
     } else if (exceptionClass.equals("java.lang.NoSuchMethodError") ||
                exceptionClass.equals("java.lang.NoSuchFieldError")) {


### PR DESCRIPTION
I depended on a library compiled for Java 21 and stumbled upon this error.
I was quite puzzled by the error message - however after some testing I was able to confirm that Java 17 libraries work fine whilst Java 18 libraries (and later) do not.
This PR fixes the confusing error message.