### PR TITLE
Removed Irrelevant Desktop Tooltip on Windows (#1122)

### DIFF
--- a/app/windows/Processing.wxs
+++ b/app/windows/Processing.wxs
@@ -24,7 +24,7 @@
     <Component Id="ApplicationShortcut" Guid="b15e6d69-f054-4ec2-aade-8e3756b537d6">
         <Shortcut Id="ApplicationStartMenuShortcut"
                   Name="Processing"
-                  Description="My Application Description"
+                  Description="Processing — An open-source visual arts programming language by the Processing Foundation"
                   Directory="ApplicationProgramsFolder"
                   Target="[INSTALLFOLDER]\Processing.exe"
                   WorkingDirectory="INSTALLFOLDER"/>


### PR DESCRIPTION
### Resolves 
Resolves #1122

### Changes: 
Tooltip description is now changed from "My Application Description" to "Processing — An open-source visual arts programming language by the Processing Foundation"

### Checklist

1.  Changes tested locally
2.  Processing still builds and runs
3.  Issue discussed and assigned before starting
4.  PR branch is up-to-date with main

