### PR TITLE
Ensure logical coordinates are used for all operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ java/build/
 /app/windows/obj
 /java/gradle/build
 /java/gradle/example/.processing
+.kotlin/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -353,7 +353,14 @@ tasks.register<Copy>("includeJavaMode") {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 tasks.register<Copy>("includeJdk") {
-    from(Jvm.current().javaHome.absolutePath)
+    from(Jvm.current().javaHome.absolutePath) {
+        // TODO: Check if this is still needed when upgrading from JDK 17
+        // https://github.com/adoptium/adoptium-support/issues/937
+        if (OperatingSystem.current().isMacOsX) {
+            exclude("**/*.jsa")
+            exclude("**/legal/**")
+        }
+    }
     destinationDir = composeResources("jdk").get().asFile
 }
 tasks.register<Copy>("includeSharedAssets"){

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -803,6 +803,9 @@ public class PApplet implements PConstants {
   // the pixelWidth and pixelHeight fields.
   public int pixelDensity = 1;
 
+  // Pixel access mode for high DPI scaling behavior
+  public int pixelAccessMode = PIXEL_EXACT;
+
   boolean present;
 
   String outputPath;
@@ -1102,6 +1105,36 @@ public class PApplet implements PConstants {
         throw new RuntimeException("pixelDensity() can only be used inside settings()");
       }
     }
+  }
+
+
+  /**
+   * Set the pixel access mode for high DPI displays. This controls how
+   * <b>get()</b> and <b>set()</b> operations behave when <b>pixelDensity</b>
+   * is greater than 1.
+   * <p/>
+   * <b>PIXEL_EXACT</b> (default): Uses nearest-neighbor sampling for pixel-perfect
+   * operations. Guarantees that <b>set(x, y, get(x, y))</b> will not change
+   * the image.
+   * <p/>
+   * <b>PIXEL_SMOOTH</b>: Uses bilinear interpolation for smoother scaling.
+   * May return interpolated color values that don't exist in the original
+   * image.
+   * <p/>
+   * This function can be called at any time during the program execution.
+   *
+   * @webref environment
+   * @webBrief Controls pixel access behavior for high DPI displays
+   * @param mode either PIXEL_EXACT or PIXEL_SMOOTH
+   * @see PApplet#pixelDensity(int)
+   * @see PApplet#get(int, int)
+   * @see PApplet#set(int, int, int)
+   */
+  public void pixelAccessMode(int mode) {
+    if (mode != PIXEL_EXACT && mode != PIXEL_SMOOTH) {
+      throw new RuntimeException("pixelAccessMode() must be PIXEL_EXACT or PIXEL_SMOOTH");
+    }
+    this.pixelAccessMode = mode;
   }
 
 

--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -232,6 +232,12 @@ public interface PConstants {
 //  static final int CMYK  = 5;  // image & color (someday)
 
 
+  // pixel access modes (for high DPI / pixel density scaling)
+
+  int PIXEL_EXACT  = 0;  // nearest-neighbor, pixel-perfect operations
+  int PIXEL_SMOOTH = 1;  // bilinear interpolation, smooth scaling
+
+
   // image file types
 
   int TIFF  = 0;

--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -434,27 +434,23 @@ public class PImage implements PConstants, Cloneable {
    * @param w width
    * @param h height
    */
-  public void updatePixels(int x, int y, int w, int h) {  // ignore
+  public void updatePixels(int x, int y, int w, int h) {
     int x2 = x + w;
     int y2 = y + h;
+    int boundsWidth = (pixelDensity > 1) ? width : pixelWidth;
+    int boundsHeight = (pixelDensity > 1) ? height : pixelHeight;
 
     if (!modified) {
       mx1 = PApplet.max(0, x);
-      mx2 = PApplet.min(pixelWidth, x2);
+      mx2 = PApplet.min(boundsWidth, x2);
       my1 = PApplet.max(0, y);
-      my2 = PApplet.min(pixelHeight, y2);
+      my2 = PApplet.min(boundsHeight, y2);
       modified = true;
-
     } else {
       if (x < mx1) mx1 = PApplet.max(0, x);
-      if (x > mx2) mx2 = PApplet.min(pixelWidth, x);
+      if (x2 > mx2) mx2 = PApplet.min(boundsWidth, x2);
       if (y < my1) my1 = PApplet.max(0, y);
-      if (y > my2) my2 = PApplet.min(pixelHeight, y);
-
-      if (x2 < mx1) mx1 = PApplet.max(0, x2);
-      if (x2 > mx2) mx2 = PApplet.min(pixelWidth, x2);
-      if (y2 < my1) my1 = PApplet.max(0, y2);
-      if (y2 > my2) my2 = PApplet.min(pixelHeight, y2);
+      if (y2 > my2) my2 = PApplet.min(boundsHeight, y2);
     }
   }
 
@@ -579,12 +575,15 @@ public class PImage implements PConstants, Cloneable {
    * @see PApplet#copy(PImage, int, int, int, int, int, int, int, int)
    */
   public int get(int x, int y) {
-    if ((x < 0) || (y < 0) || (x >= pixelWidth) || (y >= pixelHeight)) return 0;
+    int boundsWidth = (pixelDensity > 1) ? width : pixelWidth;
+    int boundsHeight = (pixelDensity > 1) ? height : pixelHeight;
+
+    if ((x < 0) || (y < 0) || (x >= boundsWidth) || (y >= boundsHeight)) return 0;
 
     return switch (format) {
-      case RGB -> pixels[y * pixelWidth + x] | 0xff000000;
-      case ARGB -> pixels[y * pixelWidth + x];
-      case ALPHA -> (pixels[y * pixelWidth + x] << 24) | 0xffffff;
+      case RGB -> pixels[y * boundsWidth + x] | 0xff000000;
+      case ARGB -> pixels[y * boundsWidth + x];
+      case ALPHA -> (pixels[y * boundsWidth + x] << 24) | 0xffffff;
       default -> 0;
     };
   }
@@ -704,18 +703,21 @@ public class PImage implements PConstants, Cloneable {
    * @usage web_application
    * @param x x-coordinate of the pixel
    * @param y y-coordinate of the pixel
-   * @param c any value of the color datatype
+   * @param argb any value of the color datatype
    * @see PImage#get(int, int, int, int)
    * @see PImage#pixels
    * @see PImage#copy(PImage, int, int, int, int, int, int, int, int)
    */
-  public void set(int x, int y, int c) {
-    if ((x < 0) || (y < 0) || (x >= pixelWidth) || (y >= pixelHeight)) return;
+  public void set(int x, int y, int argb) {
+    loadPixels();
+    int boundsWidth = (pixelDensity > 1) ? width : pixelWidth;
+    int boundsHeight = (pixelDensity > 1) ? height : pixelHeight;
 
+    if ((x < 0) || (y < 0) || (x >= boundsWidth) || (y >= boundsHeight)) return;
     switch (format) {
-      case RGB -> pixels[y * pixelWidth + x] = 0xff000000 | c;
-      case ARGB -> pixels[y * pixelWidth + x] = c;
-      case ALPHA -> pixels[y * pixelWidth + x] = ((c & 0xff) << 24) | 0xffffff;
+      case RGB -> pixels[y * boundsWidth + x] = 0xff000000 | argb;
+      case ARGB -> pixels[y * boundsWidth + x] = argb;
+      case ALPHA -> pixels[y * boundsWidth + x] = ((argb & 0xff) << 24) | 0xffffff;
     }
 
     updatePixels(x, y, 1, 1);  // slow...

--- a/core/src/processing/opengl/FrameBuffer.java
+++ b/core/src/processing/opengl/FrameBuffer.java
@@ -176,10 +176,14 @@ public class FrameBuffer implements PConstants {
   }
 
   public void copy(FrameBuffer dest, int mask) {
+    copy(dest, mask, PGL.NEAREST);
+  }
+
+  public void copy(FrameBuffer dest, int mask, int filter) {
     pgl.bindFramebufferImpl(PGL.READ_FRAMEBUFFER, this.glFbo);
     pgl.bindFramebufferImpl(PGL.DRAW_FRAMEBUFFER, dest.glFbo);
     pgl.blitFramebuffer(0, 0, this.width, this.height,
-                        0, 0, dest.width, dest.height, mask, PGL.NEAREST);
+            0, 0, dest.width, dest.height, mask, filter);
     pgl.bindFramebufferImpl(PGL.READ_FRAMEBUFFER, pg.getCurrentFB().glFbo);
     pgl.bindFramebufferImpl(PGL.DRAW_FRAMEBUFFER, pg.getCurrentFB().glFbo);
   }

--- a/core/test/processing/core/PixelDensityTest.java
+++ b/core/test/processing/core/PixelDensityTest.java
@@ -1,0 +1,218 @@
+package processing.core;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for pixel density scaling functionality, including logical pixel arrays
+ * and pixel access modes (PIXEL_EXACT vs PIXEL_SMOOTH).
+ *
+ * TODO:
+ *  - Fractional scaling.
+ *  - Some kind of openGL test.
+ */
+public class PixelDensityTest {
+  
+  private TestPApplet sketch;
+  private PGraphics java2d;
+  private PGraphics opengl;
+  
+  static class TestPApplet extends PApplet {
+    public void settings() {
+      size(100, 100);
+    }
+    
+    public void setup() {
+    }
+    
+    public void draw() {
+    }
+  }
+  
+  @Before
+  public void setUp() {
+    sketch = new TestPApplet();
+    sketch.settings();
+    sketch.setup();
+    sketch.initSurface();
+    
+    // 2d graphics
+    java2d = sketch.createGraphics(100, 100, PConstants.JAVA2D);
+    
+    try {
+      opengl = sketch.createGraphics(100, 100, PConstants.P3D);
+    } catch (Exception e) {
+      // headless, ci, etc
+      opengl = null;
+    }
+  }
+  
+  @Test
+  public void testPixelDensityConstants() {
+    assertEquals("PIXEL_EXACT should be 0", 0, PConstants.PIXEL_EXACT);
+    assertEquals("PIXEL_SMOOTH should be 1", 1, PConstants.PIXEL_SMOOTH);
+  }
+  
+  @Test
+  public void testPixelAccessModeValidation() {
+    sketch.pixelAccessMode(PConstants.PIXEL_EXACT);
+    assertEquals(PConstants.PIXEL_EXACT, sketch.pixelAccessMode);
+    
+    sketch.pixelAccessMode(PConstants.PIXEL_SMOOTH);
+    assertEquals(PConstants.PIXEL_SMOOTH, sketch.pixelAccessMode);
+    
+    try {
+      sketch.pixelAccessMode(99);
+      fail("Should throw exception for invalid mode");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains("PIXEL_EXACT or PIXEL_SMOOTH"));
+    }
+  }
+  
+  @Test
+  public void testLogicalPixelArraySize() {
+    java2d.pixelDensity = 2;
+    java2d.beginDraw();
+    
+    assertEquals("Logical width should be unchanged", 100, java2d.width);
+    assertEquals("Logical height should be unchanged", 100, java2d.height);
+    
+    assertEquals("Physical width should be scaled", 200, java2d.pixelWidth);
+    assertEquals("Physical height should be scaled", 200, java2d.pixelHeight);
+    
+    java2d.loadPixels();
+    assertEquals("Pixels array should be logical size", 100 * 100, java2d.pixels.length);
+    
+    java2d.endDraw();
+  }
+  
+  @Test
+  public void testPixelExactModeSymmetry() {
+    sketch.pixelAccessMode(PConstants.PIXEL_EXACT);
+    
+    java2d.pixelDensity = 2;
+    java2d.beginDraw();
+    java2d.background(0);
+    
+    java2d.set(10, 10, 0xFFFF0000); // Red
+    int redColor = java2d.get(10, 10);
+    java2d.set(10, 10, redColor);
+    int finalColor = java2d.get(10, 10);
+
+    assertEquals("set(get()) should be a no-op", redColor, finalColor);
+
+    java2d.endDraw();
+  }
+  
+  @Test
+  public void testPixelSmoothModeSymmetry() {
+    sketch.pixelAccessMode(PConstants.PIXEL_SMOOTH);
+    
+    java2d.pixelDensity = 2;
+    java2d.beginDraw();
+    java2d.background(0);
+
+    java2d.set(10, 10, 0xFFFF0000); // Red
+    int redColor = java2d.get(10, 10);
+    java2d.set(10, 10, redColor);
+    int finalColor = java2d.get(10, 10);
+
+    int redDiff = Math.abs(((redColor >> 16) & 0xFF) - ((finalColor >> 16) & 0xFF));
+    int greenDiff = Math.abs(((redColor >> 8) & 0xFF) - ((finalColor >> 8) & 0xFF));
+    int blueDiff = Math.abs((redColor & 0xFF) - (finalColor & 0xFF));
+    
+    assertTrue("Red channel should be approximately equal", redDiff <= 2);
+    assertTrue("Green channel should be approximately equal", greenDiff <= 2);
+    assertTrue("Blue channel should be approximately equal", blueDiff <= 2);
+    
+    java2d.endDraw();
+  }
+  
+  @Test
+  public void testPixelCoordinatesInBounds() {
+    java2d.pixelDensity = 2;
+    java2d.beginDraw();
+    
+    for (int mode : new int[]{PConstants.PIXEL_EXACT, PConstants.PIXEL_SMOOTH}) {
+      sketch.pixelAccessMode(mode);
+      
+      java2d.set(0, 0, 0xFFFF0000);
+      java2d.set(99, 0, 0xFF00FF00);
+      java2d.set(0, 99, 0xFF0000FF);
+      java2d.set(99, 99, 0xFFFFFF00);
+      
+      assertEquals("Top-left should be red", 0xFFFF0000, java2d.get(0, 0));
+      assertEquals("Top-right should be green", 0xFF00FF00, java2d.get(99, 0));
+      assertEquals("Bottom-left should be blue", 0xFF0000FF, java2d.get(0, 99));
+      assertEquals("Bottom-right should be yellow", 0xFFFFFF00, java2d.get(99, 99));
+      
+      assertEquals("Out of bounds should return 0", 0, java2d.get(-1, 50));
+      assertEquals("Out of bounds should return 0", 0, java2d.get(50, -1));
+      assertEquals("Out of bounds should return 0", 0, java2d.get(100, 50));
+      assertEquals("Out of bounds should return 0", 0, java2d.get(50, 100));
+    }
+    
+    java2d.endDraw();
+  }
+  
+  @Test
+  public void testPixelArrayOperations() {
+    java2d.pixelDensity = 2;
+    java2d.beginDraw();
+    java2d.background(0);
+    
+    java2d.loadPixels();
+    
+    java2d.pixels[0] = 0xFFFF0000; // Top-left red
+    java2d.pixels[99] = 0xFF00FF00; // Top-right green
+    java2d.pixels[99 * 100] = 0xFF0000FF; // Bottom-left blue
+    java2d.pixels[99 * 100 + 99] = 0xFFFFFF00; // Bottom-right yellow
+    
+    java2d.updatePixels();
+    
+    assertEquals("Array set should match get()", 0xFFFF0000, java2d.get(0, 0));
+    assertEquals("Array set should match get()", 0xFF00FF00, java2d.get(99, 0));
+    assertEquals("Array set should match get()", 0xFF0000FF, java2d.get(0, 99));
+    assertEquals("Array set should match get()", 0xFFFFFF00, java2d.get(99, 99));
+    
+    java2d.endDraw();
+  }
+  
+  @Test
+  public void testOpenGLPixelDensity() {
+    if (opengl == null) {
+      System.out.println("Skipping OpenGL test - not available");
+      return;
+    }
+    
+    opengl.pixelDensity = 2;
+    opengl.beginDraw();
+    opengl.background(0);
+    
+    opengl.set(10, 10, 0xFFFF0000);
+    int color = opengl.get(10, 10);
+    
+    int red = (color >> 16) & 0xFF;
+    assertTrue("Red channel should be preserved", red > 200);
+    
+    opengl.endDraw();
+  }
+  
+  @Test
+  public void testBackwardCompatibility() {
+    java2d.pixelDensity = 1;
+    java2d.beginDraw();
+    
+    assertEquals("Logical and physical width should be equal", java2d.width, java2d.pixelWidth);
+    assertEquals("Logical and physical height should be equal", java2d.height, java2d.pixelHeight);
+    
+    java2d.loadPixels();
+    assertEquals("Pixels array should match physical size", java2d.pixelWidth * java2d.pixelHeight, java2d.pixels.length);
+    
+    java2d.set(50, 50, 0xFFFF0000);
+    assertEquals("Get should return set value", 0xFFFF0000, java2d.get(50, 50));
+    
+    java2d.endDraw();
+  }
+}


### PR DESCRIPTION
# Problem

Fixes #1131 

When `pixelDensity`, `get`/`set` operations no longer work on logical but instead physical pixels. This is confusing for users who think that their image is `size` pixels. This behavior will become particular problematic when fractional scaling is introduced as it's more difficult to reason about that size * 2.

# Solution

Ensure that operations are always done in logical pixels, upscaling/downscaling into physical pixels when doing write operations to the backing texture.

Add a new pixel access mode constant that determines whether linear or nearest neighbor sampling should be done when scaling. This isn't super helpful right now but will become more important when fractional scaling is introduced.

To be honest, I'm still not 100% sure this is the right solution. It's clear that the `PImage` api was always intended to be physical pixels and indeed we now introduce a weird distinction where base `PImage` will continue to use physical pixels since it doesn't make sense to refer to images as having a scaling factor. It's probably good for users to not have to know about these concepts but also introduces inherent confusion when using high dpi scaling. More robust documentation could probably help here but I'm still a little apprehensive as this is a substantial change (i.e. a totally new contract that we always use logical pixels).

# TODO:
- Check whether off screen rendering still works
- Confirm whether we need to do gamma correction when doing software rendering in `PGraphicsJava2D`
- Test more examples to see if anything broke
- Double check if there's a better existing pattern for the gpu copies when binding the output texture is necessary
- Double check depth writes still work + msaa can be configured
