### PR TITLE
Issue templates: Change the default option to "No, I’m just reporting the issue"

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -94,8 +94,8 @@ body:
 
       See [CONTRIBUTING.md](https://github.com/processing/processing4/blob/main/CONTRIBUTING.md) to learn more about how to get involved.
     options:
-      - Yes, I’d like to help with this
       - No, I’m just reporting the issue
+      - Yes, I’d like to help with this
       - I’m not sure yet
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/2_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2_enhancement.yml
@@ -75,8 +75,8 @@ body:
 
       See [CONTRIBUTING.md](https://github.com/processing/processing4/blob/main/CONTRIBUTING.md) to learn more about how to get involved.
     options:
-      - Yes, I’d like to help with this
       - No, I’m just reporting the issue
+      - Yes, I’d like to help with this
       - I’m not sure yet
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/3_feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3_feature-request.yml
@@ -72,8 +72,8 @@ body:
 
       See [CONTRIBUTING.md](https://github.com/processing/processing4/blob/main/CONTRIBUTING.md) to learn more about how to get involved.
     options:
-      - Yes, I’d like to help with this
       - No, I’m just reporting the issue
+      - Yes, I’d like to help with this
       - I’m not sure yet
   validations:
     required: true


### PR DESCRIPTION
This is not ideal, but there is no way to require users to manually pick an option in dropdowns.

### Context

> The new issue templates are awesome, but we've noticed that dropdowns are auto-populating with the first value, even if they're listed as required. This is counterintuitive as it means that if the user does nothing, the value will still be populated, possibly with incorrect data. I think that default values are useful, but should be opt-in for template writers to avoid confusion with end users. For required fields, a warning should be provided if a user fails to select an option.

Source: https://github.com/orgs/community/discussions/150368