### PR TITLE
Issue template: fix description to be value field

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3_feature-request.yml
@@ -42,6 +42,8 @@ body:
   attributes:
     label: Feature details
     description: |
+      Describe the feature you’d like to see added to Processing.
+    value: |
       #### Feature description
       Describe the feature in detail. Include how it should work and its intended impact.
 


### PR DESCRIPTION
Sorry I mixed up the `value` and `description` fields 🫣