### PR TITLE
Set Linux confinement to classic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -247,7 +247,7 @@ tasks.register("generateSnapConfiguration"){
     summary: A creative coding editor
     description: |
       Processing is a flexible software sketchbook and a programming language designed for learning how to code.
-    confinement: strict
+    confinement: classic
     
     apps:
       processing:


### PR DESCRIPTION
Snap’s containment features seemed like a good way to offer a more secure binary, so we initially opted in. In hindsight, that choice introduced more restrictions than expected for Processing’s typical use cases, particularly in education or when using serial devices, custom libraries, or sketches that expect full file access.

See further discussion here: https://discourse.processing.org/t/integration-of-processing-into-ubuntu/46568/5

- [x] Request Classic confinement from Snap

Fixes #1186 
Fixes #1147 
Fixes #1119
Fixes #995 