### PR TITLE
CLITest for testing CLI commands in Processing IDE

### DIFF
--- a/app/test/processing/app/CLITest.kt
+++ b/app/test/processing/app/CLITest.kt
@@ -1,0 +1,50 @@
+package processing.app
+
+import java.io.File
+import kotlin.test.Test
+
+/*
+This class is used to test the CLI commands of the Processing IDE.
+It mostly exists to quickly run CLI commands without having to specify run configurations
+or to manually run it on the command line.
+
+In IntelliJ IDEA, it should display runnable arrows next to each test method.
+Use this to quickly test the CLI commands.
+The output will be displayed in the console after `Running CLI with arguments: ...`.
+When developing on the CLI commands, feel free to add more test methods here.
+ */
+class CLITest {
+
+    @Test
+    fun testLSP(){
+        runCLIWithArguments("lsp")
+    }
+
+    @Test
+    fun testLegacyCLI(){
+        runCLIWithArguments("cli --help")
+    }
+
+    /*
+    This function runs the CLI with the given arguments.
+     */
+    fun runCLIWithArguments(args: String) {
+        // TODO: Once Processing PDE correctly builds in IntelliJ IDEA switch over to using the code directly
+        // To see if the PDE builds correctly can be tested by running the Processing.kt main function directly in IntelliJ IDEA
+        // Set the JAVA_HOME environment variable to the JDK used by the IDE
+        println("Running CLI with arguments: $args")
+        val process = ProcessBuilder("./gradlew", "run", "--args=$args", "--quiet")
+            .directory(File(System.getProperty("user.dir")).resolve("../../../"))
+            .inheritIO()
+
+        process.environment().apply {
+            put("JAVA_HOME", System.getProperty("java.home"))
+        }
+
+        val result = process
+            .start()
+            .waitFor()
+        println("Done running CLI with arguments: $args (Result: $result)")
+
+    }
+}


### PR DESCRIPTION
Easily run Processing command line arguments from IntelliJ IDEA

<img width="1840" alt="Screenshot 2025-06-28 at 10 38 29" src="https://github.com/user-attachments/assets/0bc01fd8-7aa2-4278-84f4-f5252dfce7d3" />

