### PR TITLE
Properly clear EditorStatus.message with empty()

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2665,7 +2665,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
    * Clear the status area.
    */
   public void statusEmpty() {
-    statusNotice(EMPTY);
+    status.empty();
   }
 
 


### PR DESCRIPTION
Partially resolves #1167 - EditorStatus.message no longer gets set to a string of spaces when cleared, which caused some UI bugs.