### PR TITLE
Debugger continues to work despite Sketch name and folder name are not equal

### DIFF
--- a/java/src/processing/mode/java/debug/LineBreakpoint.java
+++ b/java/src/processing/mode/java/debug/LineBreakpoint.java
@@ -208,7 +208,7 @@ public class LineBreakpoint implements ClassLoadListener {
   protected String className() {
     if (line.fileName().endsWith(".pde")) {
       // standard tab
-      return dbg.getEditor().getSketch().getName();
+      return line.fileName().substring(0, line.fileName().lastIndexOf(".pde"));
     }
 
     if (line.fileName().endsWith(".java")) {


### PR DESCRIPTION
### Resolves
This PR resolves #1190 

### Changes
* Modified line 211 in java/src/processing/mode/java/debug/LineBreakpoint.java to allow .pde files to return its filename 
* Inserted a new function in java/src/processing/mode/java/debug/Debugger.java to check and translate PDE files if they are mismatched with their folder.

### Tests
- [x] We ran ./gradlew test, built successfully.
- [x] Ran ./gradlew run, built IDE successfully.
- [x] Tested the debugger to notice any change in its behavior.

### Screenshots
#### Before Implementation
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/cb359c69-fdd5-4202-ae99-0b206658345c" />

#### After Implementation
<img width="680" height="581" alt="1190 issue solution" src="https://github.com/user-attachments/assets/31e70ed8-3b49-42ae-a6cb-9eee2e2818ec" />
