### PR TITLE
Display Welcome to Beta once per revision

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -424,7 +424,6 @@ tasks.register<Copy>("renameWindres") {
 }
 tasks.register("includeProcessingResources"){
     dependsOn(
-        "includeJdk",
         "includeCore",
         "includeJavaMode",
         "includeSharedAssets",
@@ -433,6 +432,7 @@ tasks.register("includeProcessingResources"){
         "includeJavaModeResources",
         "renameWindres"
     )
+    mustRunAfter("includeJdk")
     finalizedBy("signResources")
 }
 
@@ -539,6 +539,7 @@ afterEvaluate {
         dependsOn("includeProcessingResources")
     }
     tasks.named("createDistributable").configure {
+        dependsOn("includeJdk")
         finalizedBy("setExecutablePermissions")
     }
 }

--- a/app/src/processing/app/UpdateCheck.java
+++ b/app/src/processing/app/UpdateCheck.java
@@ -113,6 +113,7 @@ public class UpdateCheck {
                                     System.getProperty("os.arch"));
 
     int latest = readInt(LATEST_URL + "?" + info);
+    int revision = Base.getRevision();
 
     String lastString = Preferences.get("update.last");
     long now = System.currentTimeMillis();
@@ -127,27 +128,17 @@ public class UpdateCheck {
 
     if (base.activeEditor != null) {
 
-      if (latest > Base.getRevision()) {
+      if (latest > revision) {
         System.out.println("You are running Processing revision 0" +
-                           Base.getRevision() + ", the latest build is 0" +
+                           revision + ", the latest build is 0" +
                            latest + ".");
         // Assume the person is busy downloading the latest version
 //        offerToUpdateContributions = !promptToVisitDownloadPage();
         promptToVisitDownloadPage();
       }
 
-      String lastBetaSeenStr = Preferences.get("beta.last_beta_welcome_seen");
-      int lastBetaSeen = 0;
-      if (lastBetaSeenStr != null) {
-          lastBetaSeen = Integer.parseInt(lastBetaSeenStr);
-      }
-      int revision = Base.getRevision();
-      System.err.println("MOON DEBUG" +
-              Base.getRevision() + ", and lastBetaSeen is " +
-              lastBetaSeen + ".");
-
-
-      if(latest < revision && revision != lastBetaSeen ) {
+      int lastBetaWelcomeSeen = Preferences.getInteger("update.beta_welcome");
+      if(latest < revision && revision != lastBetaWelcomeSeen ) {
           WelcomeToBeta.showWelcomeToBeta();
       }
 

--- a/app/src/processing/app/UpdateCheck.java
+++ b/app/src/processing/app/UpdateCheck.java
@@ -35,6 +35,7 @@ import processing.app.ui.WelcomeToBeta;
 import processing.core.PApplet;
 
 
+
 /**
  * Threaded class to check for updates in the background.
  * <p/>
@@ -125,7 +126,6 @@ public class UpdateCheck {
     Preferences.set("update.last", String.valueOf(now));
 
     if (base.activeEditor != null) {
-//      boolean offerToUpdateContributions = true;
 
       if (latest > Base.getRevision()) {
         System.out.println("You are running Processing revision 0" +
@@ -135,8 +135,20 @@ public class UpdateCheck {
 //        offerToUpdateContributions = !promptToVisitDownloadPage();
         promptToVisitDownloadPage();
       }
-      if(latest < Base.getRevision()){
-        WelcomeToBeta.showWelcomeToBeta();
+
+      String lastBetaSeenStr = Preferences.get("beta.last_beta_welcome_seen");
+      int lastBetaSeen = 0;
+      if (lastBetaSeenStr != null) {
+          lastBetaSeen = Integer.parseInt(lastBetaSeenStr);
+      }
+      int revision = Base.getRevision();
+      System.err.println("MOON DEBUG" +
+              Base.getRevision() + ", and lastBetaSeen is " +
+              lastBetaSeen + ".");
+
+
+      if(latest < revision && revision != lastBetaSeen ) {
+          WelcomeToBeta.showWelcomeToBeta();
       }
 
       /*

--- a/app/src/processing/app/ui/WelcomeToBeta.kt
+++ b/app/src/processing/app/ui/WelcomeToBeta.kt
@@ -35,6 +35,7 @@ import com.mikepenz.markdown.m2.markdownColor
 import com.mikepenz.markdown.m2.markdownTypography
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownTypography
+import processing.app.Preferences
 import processing.app.Base.getRevision
 import processing.app.Base.getVersionName
 import processing.app.ui.theme.LocalLocale
@@ -61,7 +62,10 @@ class WelcomeToBeta {
             val mac = SystemInfo.isMacFullWindowContentSupported
             SwingUtilities.invokeLater {
                 JFrame(windowTitle).apply {
-                    val close = { dispose() }
+                    val close = {
+                       Preferences.set("beta.last_beta_welcome_seen", getRevision().toString())
+                       dispose()
+                    }
                     rootPane.putClientProperty("apple.awt.transparentTitleBar", mac)
                     rootPane.putClientProperty("apple.awt.fullWindowContent", mac)
                     defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE

--- a/app/src/processing/app/ui/WelcomeToBeta.kt
+++ b/app/src/processing/app/ui/WelcomeToBeta.kt
@@ -63,7 +63,7 @@ class WelcomeToBeta {
             SwingUtilities.invokeLater {
                 JFrame(windowTitle).apply {
                     val close = {
-                       Preferences.set("beta.last_beta_welcome_seen", getRevision().toString())
+                       Preferences.set("update.beta_welcome", getRevision().toString())
                        dispose()
                     }
                     rootPane.putClientProperty("apple.awt.transparentTitleBar", mac)

--- a/build/shared/lib/defaults.txt
+++ b/build/shared/lib/defaults.txt
@@ -76,6 +76,10 @@ theme.gradient.method = rgb
 # on how many people are using Processing)
 update.check = true
 
+# default value for beta_welcome
+# -1 means no beta has been run
+update.beta_welcome = -1
+
 # on windows, automatically associate .pde files with processing.exe
 platform.auto_file_type_associations = true
 


### PR DESCRIPTION
Limits the Welcome to Beta screen to once per downloaded revision.

Closes #1198 