### PR TITLE
New links in "Help" menu for issues and forum 

### DIFF
--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -151,6 +151,8 @@ menu.help.reference.download = Download Offline Reference
 menu.help.libraries_reference = Libraries Reference
 menu.help.tools_reference = Tools Reference
 menu.help.empty = (empty)
+menu.help.report = Report a bug
+menu.help.ask = Ask on the Forum
 menu.help.online = Online
 
 # Only include the .url lines in the translation file if there
@@ -167,6 +169,8 @@ menu.help.foundation = The Processing Foundation
 menu.help.foundation.url = https://processing.foundation/
 menu.help.visit = Visit Processing.org
 menu.help.visit.url = https://processing.org/
+menu.help.report.url = https://github.com/processing/processing4/issues
+menu.help.ask.url = https://discourse.processing.org
 
 
 # ---------------------------------------

--- a/build/shared/lib/languages/PDE_de.properties
+++ b/build/shared/lib/languages/PDE_de.properties
@@ -121,6 +121,8 @@ menu.help.troubleshooting = Fehlerbehandlung
 menu.help.faq = Häufig gestellte Fragen (FAQ)
 menu.help.foundation = "The Processing Foundation"
 menu.help.visit = Processing.org besuchen
+menu.help.report = Einen Fehler melden
+menu.help.ask = Im Forum fragen
 
 
 # ---------------------------------------

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -332,28 +332,12 @@ public class JavaEditor extends Editor {
 
     // Report a bug link opener
     item = new JMenuItem(Language.text("menu.help.report"));
-    item.addActionListener(e -> {
-      Desktop desktop = java.awt.Desktop.getDesktop();
-      try {
-        URI oURL = new URI(Language.text("menu.help.report.url"));
-        desktop.browse(oURL);
-      } catch (IOException | URISyntaxException ex) {
-        throw new RuntimeException(ex);
-      }
-    });
+    item.addActionListener(e -> Platform.openURL(Language.text("menu.help.report.url")));
     menu.add(item);
 
     // Ask on the Forum link opener
     item = new JMenuItem(Language.text("menu.help.ask"));
-    item.addActionListener(e -> {
-      Desktop desktop = java.awt.Desktop.getDesktop();
-      try {
-        URI oURL = new URI(Language.text("menu.help.ask.url"));
-        desktop.browse(oURL);
-      } catch (IOException | URISyntaxException ex) {
-        throw new RuntimeException(ex);
-      }
-    });
+    item.addActionListener(e -> Platform.openURL(Language.text("menu.help.getting_started.url")));
     menu.add(item);
 
     menu.addSeparator();

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -36,9 +36,6 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.text.BadLocationException;

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -36,6 +36,9 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.text.BadLocationException;
@@ -323,6 +326,34 @@ public class JavaEditor extends Editor {
 //      "menu.help.reference.update" : "menu.help.reference.download");
     item = new JMenuItem(Language.text("menu.help.reference.download"));
     item.addActionListener(e -> new Thread(this::downloadReference).start());
+    menu.add(item);
+
+    menu.addSeparator();
+
+    // Report a bug link opener
+    item = new JMenuItem(Language.text("menu.help.report"));
+    item.addActionListener(e -> {
+      Desktop desktop = java.awt.Desktop.getDesktop();
+      try {
+        URI oURL = new URI(Language.text("menu.help.report.url"));
+        desktop.browse(oURL);
+      } catch (IOException | URISyntaxException ex) {
+        throw new RuntimeException(ex);
+      }
+    });
+    menu.add(item);
+
+    // Ask on the Forum link opener
+    item = new JMenuItem(Language.text("menu.help.ask"));
+    item.addActionListener(e -> {
+      Desktop desktop = java.awt.Desktop.getDesktop();
+      try {
+        URI oURL = new URI(Language.text("menu.help.ask.url"));
+        desktop.browse(oURL);
+      } catch (IOException | URISyntaxException ex) {
+        throw new RuntimeException(ex);
+      }
+    });
     menu.add(item);
 
     menu.addSeparator();


### PR DESCRIPTION
Added two links to the help menu bar. Opens either processing forum or GitHub issues tab in standard browser when clicked. Resolves Issue #1208 
Implemented the new features in JavaEditor.java and also provided German language support. 
Used Desktop.getDesktop() and then Desktop.browse(oURL) to follow the link. 
I Placed the MenuItems between "Download official reference" and "library reference".

I will change the code ASAP when somethings bugging or the I messed up with the style guidelines. 
 