### PR TITLE
Fix formatting in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -42,7 +42,7 @@ body:
 - type: input
   attributes:
     label: Operating system
-    description: "Ex: Windows/MacOSX/Linux/Android/iOS along with version"
+    description: "Ex: Windows/macOS/Linux/Android/iOS along with version"
   validations:
     required: true
 
@@ -60,11 +60,11 @@ body:
     label: Steps to reproduce this
     description: Describe what steps will produce the bug.
     value: |
-      "1.
+      1.
 
       2.
 
-      3."
+      3.
   validations:
     required: true
 


### PR DESCRIPTION
Removed the unnecessary quotes and renamed MacOSX to macOS