### PR TITLE
Updated URL Mistake for PR #1210 and Issue #1208

### DIFF
--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -334,7 +334,7 @@ public class JavaEditor extends Editor {
 
     // Ask on the Forum link opener
     item = new JMenuItem(Language.text("menu.help.ask"));
-    item.addActionListener(e -> Platform.openURL(Language.text("menu.help.getting_started.url")));
+    item.addActionListener(e -> Platform.openURL(Language.text("menu.help.ask.url")));
     menu.add(item);
 
     menu.addSeparator();


### PR DESCRIPTION
Here is the new PR for the mistake in #1208 / #1210. 
Changed wrong URL Component from `"menu.help.getting_started.url"` to `"menu.help.ask.url"`. 
Hope now everything is in the right place :). 

Closes #1208 