### PR TITLE
Add warning for default pixelDensity behavior

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2055,7 +2055,7 @@ public class PApplet implements PConstants {
       setup();
 
       if(pixelDensityWarning){
-        System.err.println("Warning: pixelDensity() now defaults to 2x to align with your display's pixel density. To avoid this warning, please explicitly set pixelDensity() in settings().");
+        System.err.println("Warning: Processing now sets pixelDensity(2) by default on high-density screens. This may change how your sketch looks. To revert to the old behavior, set pixelDensity(1) in setup().");
       }
 
     } else {  // frameCount > 0, meaning an actual draw()

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -802,6 +802,7 @@ public class PApplet implements PConstants {
   // Unlike the others above, needs to be public to support
   // the pixelWidth and pixelHeight fields.
   public int pixelDensity = 1;
+  boolean pixelDensityWarning = false;
 
   boolean present;
 
@@ -1082,6 +1083,9 @@ public class PApplet implements PConstants {
   */
   public void pixelDensity(int density) {
     //println(density + " " + this.pixelDensity);
+
+
+    this.pixelDensityWarning = false;
     if (density != this.pixelDensity) {
       if (insideSettings("pixelDensity", density)) {
         if (density != 1 && density != 2) {
@@ -2049,6 +2053,10 @@ public class PApplet implements PConstants {
 
     if (frameCount == 0) {
       setup();
+
+      if(pixelDensityWarning){
+        System.err.println("Warning: pixelDensity() now defaults to 2x to align with your display's pixel density. To avoid this warning, please explicitly set pixelDensity() in settings().");
+      }
 
     } else {  // frameCount > 0, meaning an actual draw()
       // update the current frameRate
@@ -10106,6 +10114,7 @@ public class PApplet implements PConstants {
     sketch.fullScreen = fullScreen;
 
     sketch.pixelDensity = sketch.displayDensity();
+    sketch.pixelDensityWarning = sketch.pixelDensity > 1;
 
     // For 3.0.1, moved this above handleSettings() so that loadImage() can be
     // used inside settings(). Sets a terrible precedent, but the alternative


### PR DESCRIPTION
Introduces a warning message when pixelDensity defaults to 2x to match the display's pixel density. The warning prompts users to explicitly set pixelDensity in settings() to avoid the message.


<img width="1046" height="711" alt="Screenshot 2025-09-04 at 15 44 55" src="https://github.com/user-attachments/assets/6fc0a51f-4059-45d8-8e50-97b0c100009a" />
