### PR TITLE
Adding the sketch format command

### DIFF
--- a/app/src/processing/app/Processing.kt
+++ b/app/src/processing/app/Processing.kt
@@ -11,11 +11,26 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
 import processing.app.api.Contributions
+import processing.app.api.SketchCommand
 import processing.app.api.Sketchbook
 import processing.app.ui.Start
 import java.io.File
 import java.util.prefs.Preferences
 import kotlin.concurrent.thread
+
+
+
+suspend fun main(args: Array<String>){
+    Processing()
+        .subcommands(
+            LSP(),
+            LegacyCLI(args),
+            Contributions(),
+            Sketchbook(),
+            SketchCommand()
+        )
+        .main(args)
+}
 
 class Processing: SuspendingCliktCommand("processing"){
     val version by option("-v","--version")
@@ -46,16 +61,6 @@ class Processing: SuspendingCliktCommand("processing"){
     }
 }
 
-suspend fun main(args: Array<String>){
-   Processing()
-        .subcommands(
-            LSP(),
-            LegacyCLI(args),
-            Contributions(),
-            Sketchbook()
-        )
-        .main(args)
-}
 
 class LSP: SuspendingCliktCommand("lsp"){
     override fun help(context: Context) = "Start the Processing Language Server"
@@ -73,7 +78,6 @@ class LSP: SuspendingCliktCommand("lsp"){
         }
     }
 }
-
 
 class LegacyCLI(val args: Array<String>): SuspendingCliktCommand("cli") {
     override val treatUnknownOptionsAsArgs = true

--- a/app/src/processing/app/api/SketchCommand.kt
+++ b/app/src/processing/app/api/SketchCommand.kt
@@ -1,0 +1,62 @@
+package processing.app.api
+
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.help
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import processing.app.Language
+import processing.app.Platform
+import processing.app.Preferences
+import java.io.File
+
+class SketchCommand: SuspendingCliktCommand("sketch"){
+    override fun help(context: Context) = "Manage a Processing sketch"
+    override suspend fun run() {
+
+    }
+    init {
+        subcommands(Format())
+    }
+
+    class Format: SuspendingCliktCommand("format"){
+        override fun help(context: Context) = "Format a Processing sketch"
+        val file by argument("file")
+            .help("Path to the sketch file to format")
+        val inPlace by option("-i","--inplace")
+            .flag()
+            .help("Format the file in place, otherwise prints to stdout")
+
+        override suspend fun run(){
+            try {
+                Platform.init()
+                Language.init()
+                Preferences.init()
+
+                // run in headless mode
+                System.setProperty("java.awt.headless", "true")
+
+                val clazz = Class.forName("processing.mode.java.AutoFormat")
+                // Indirect invocation since app does not depend on java mode
+                val formatter = clazz
+                    .getDeclaredConstructor()
+                    .newInstance()
+
+                val method = clazz.getMethod("format", String::class.java)
+                val code = File(file).readText()
+
+                val formatted = method.invoke(formatter, code) as String
+                if(inPlace) {
+                    File(file).writeText(formatted)
+                    return
+                }
+                println(formatted)
+            } catch (e: Exception) {
+                throw InternalError("Failed to invoke main method", e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the `processing sketch format` cli option for use in other extensions or cli applications, e.g. VSCode.

The cli takes the existing `processing.mode.java.AutoFormat` class from the Java Mode

(will add more info later)