### PR TITLE
CLI now supports renamed main sketch file via sketch.properties .

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1320,10 +1320,13 @@ public class Sketch {
       String main = props.get("main");
       if (main != null) {
         File mainFile = new File(folder, main);
-        if (!mainFile.exists()) {
+        if (mainFile.exists()) {
+          return mainFile;
+        }
+        else {
           System.err.println(main + " does not exist inside " + folder);
           // Fall through to the code below in case we can recover.
-          // Not removing the bad entry since this is a find() method.
+
         }
       }
     } catch (IOException e) {

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2256,19 +2256,25 @@ public abstract class Editor extends JFrame implements RunnerListener {
    * shouldn't rely on any of its variables being initialized already.
    */
   protected void handleOpenInternal(String path) throws EditorException {
-    // Prior to 4.0 beta 6, a lot of logic happened here that was
-    // instead moved into Base. Probably was here so that other Modes
-    // could override the behavior, but that was too messy. [fry 220206]
+  try {
+    File sketchFolder = new File(path);
 
-    try {
-      sketch = new Sketch(path, this);
-    } catch (IOException e) {
-      throw new EditorException("Could not create the sketch.", e);
+    // Try to locate main file using sketch.properties or fallback
+    File mainFile = Sketch.findMain(sketchFolder, Base.getModeList());
+    if (mainFile == null) {
+      throw new EditorException("No valid main .pde file found in " + sketchFolder);
     }
 
-    header.rebuild();
-    updateTitle();
+    // Use the parent folder of the main file
+    sketch = new Sketch(mainFile.getParentFile(), this);
+
+  } catch (IOException e) {
+    throw new EditorException("Could not create the sketch.", e);
   }
+
+  header.rebuild();
+  updateTitle();
+}
 
 
   /**

--- a/app/test/processing/app/CLITest.kt
+++ b/app/test/processing/app/CLITest.kt
@@ -47,4 +47,20 @@ class CLITest {
         println("Done running CLI with arguments: $args (Result: $result)")
 
     }
+    fun runCLIAndCapture(vararg args: String): String {
+        val argLine = args.joinToString(" ")
+        println("Running CLI with arguments: $argLine")
+
+        val process = ProcessBuilder("./gradlew", "run", "--args=$argLine", "--quiet")
+            .directory(File(System.getProperty("user.dir")).resolve("../../../"))
+            .redirectErrorStream(true)
+            .start()
+
+        val output = process.inputStream.bufferedReader().readText()
+        val exitCode = process.waitFor()
+
+        println("Done running CLI with arguments: $argLine (Exit code: $exitCode)")
+        return output
+    }
+
 }


### PR DESCRIPTION
This PR fixes issue [#1219]

Where the Processing CLI failed to run sketches when the main .pde file had been renamed (e.g. main.pde) and specified in sketch.properties.

Changes Made

Updated findMain() in Sketch.java:

If sketch.properties defines a main file and it exists → return it immediately.

If it does not exist → log a warning and fall back to the default <folderName>.pde.

If neither exists → return null (current error behavior preserved).