### PR TITLE
Fix the issue with the pre-processor test

### DIFF
--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -280,7 +280,7 @@ public class ParserTests {
 
   @Test
   public void bug1532() {
-    expectRecognitionException("bug1532", 50);
+    expectRecognitionException("bug1532", 43);
   }
 
   @Test

--- a/java/test/resources/bug1532.pde
+++ b/java/test/resources/bug1532.pde
@@ -19,13 +19,6 @@ Capture cam;
 flatCube[][] grid;
 
 void setup() {
-  try {
-    quicktime.QTSession.open();
-  } 
-  catch (quicktime.QTException qte) { 
-    qte.printStackTrace();
-  }
-
   size (dx,dy,OPENGL);
   int d=day();
   int m=month();


### PR DESCRIPTION
Upgrading the preprocessor made it no longer recognise the `quicktime` keyword in the `bug1532.pde` causing the test to fail. As far as I can see this test was never intended to test for that situation but rather for some invalid syntax later on line 50 of that file.

I cannot find anything about the `quicktime` keyword so I have just commented out the line with the new issue