### PR TITLE
Add 'Develop' menu for debug mode with update check

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -48,19 +48,8 @@ import javax.swing.text.*;
 import javax.swing.text.html.*;
 import javax.swing.undo.*;
 
-import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.util.SystemInfo;
-import processing.app.Base;
-import processing.app.Formatter;
-import processing.app.Language;
-import processing.app.Messages;
-import processing.app.Mode;
-import processing.app.Platform;
-import processing.app.Preferences;
-import processing.app.Problem;
-import processing.app.RunnerListener;
-import processing.app.Sketch;
-import processing.app.SketchCode;
+import processing.app.*;
 import processing.utils.SketchException;
 import processing.app.contrib.ContributionManager;
 import processing.app.laf.PdeMenuItemUI;
@@ -147,6 +136,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
   private FindReplace find;
   JMenu toolsMenu;
   JMenu modePopup;
+  JMenu developMenu;
 
   protected List<Problem> problems = Collections.emptyList();
 
@@ -680,6 +670,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
       helpMenu.setText(helpMenu.getText() + " ");
     }
     menubar.add(helpMenu);
+    updateDevelopMenu(menubar);
 
     Toolkit.setMenuMnemonics(menubar);
     setJMenuBar(menubar);
@@ -1059,6 +1050,37 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
 
   abstract public JMenu buildHelpMenu();
+
+  public void buildDevelopMenu(){
+    developMenu = new JMenu(Language.text("menu.develop"));
+
+    var updateTrigger = new JMenuItem(Language.text("menu.develop.check_for_updates"));
+    updateTrigger.addActionListener(e -> {
+        Preferences.unset("update.last");
+        new UpdateCheck(base);
+    });
+    developMenu.add(updateTrigger);
+
+  }
+
+  public void updateDevelopMenu(){
+    updateDevelopMenu(null);
+  }
+
+  void updateDevelopMenu(JMenuBar menu){
+      if(menu == null){
+          menu = getJMenuBar();
+      }
+      if(developMenu == null){
+          buildDevelopMenu();
+      }
+      if(Base.DEBUG){
+        menu.add(developMenu);
+      }else{
+        menu.remove(developMenu);
+      }
+
+  }
 
 
   public void showReference(String filename) {

--- a/app/src/processing/app/ui/EditorFooter.java
+++ b/app/src/processing/app/ui/EditorFooter.java
@@ -116,6 +116,7 @@ public class EditorFooter extends Box {
       public void mousePressed(MouseEvent e) {
         if(e.getClickCount() == 5){
           Base.DEBUG = !Base.DEBUG;
+          editor.updateDevelopMenu();
         }
         var debugInformation = String.join("\n",
             "Version: " + Base.getVersionName(),

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -172,6 +172,7 @@ menu.help.visit.url = https://processing.org/
 menu.help.report.url = https://github.com/processing/processing4/issues
 menu.help.ask.url = https://discourse.processing.org
 
+menu.develop = Develop
 
 # ---------------------------------------
 # Basics

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -173,6 +173,7 @@ menu.help.report.url = https://github.com/processing/processing4/issues
 menu.help.ask.url = https://discourse.processing.org
 
 menu.develop = Develop
+menu.develop.check_for_updates = Force Check for updates
 
 # ---------------------------------------
 # Basics


### PR DESCRIPTION
Introduces a new 'Develop' menu that appears when debug mode is enabled. I realised I needed a quick way to trigger methods within the PDE which sometimes have no link to UI yet anywhere.

To enable the debug mode, click 5 times on the version number. 

Another nice to have that this PR adds is that there is a visual indicator on whether or not debug mode is active. 