### PR TITLE
Make sure LSP recognises contributed libraries

### DIFF
--- a/java/src/processing/mode/java/lsp/PdeAdapter.java
+++ b/java/src/processing/mode/java/lsp/PdeAdapter.java
@@ -66,6 +66,8 @@ class PdeAdapter {
     this.rootPath = rootPath;
     this.client = client;
 
+    Base.locateSketchbookFolder();
+
     File location = Platform.getContentFile("modes/java");
     ModeContribution mc =
       ModeContribution.load(null, location, JavaMode.class.getName());


### PR DESCRIPTION
Trigger locating the sketchbook folder so contributed libraries are loaded when the java mode is loaded. 

Closes [processing-vscode-extension#9](https://github.com/processing/processing-vscode-extension/issues/9)