### PR TITLE
Use `start` instead of 0 for the starting index in `text`

### DIFF
--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -4768,7 +4768,7 @@ public class PGraphics extends PImage implements PConstants {
     }
 
 //    int start = 0;
-    int index = 0;
+    int index = start;
     while (index < stop) { //length) {
       if (chars[index] == '\n') {
         textLineAlignImpl(chars, start, index, x, y);


### PR DESCRIPTION
`start` can be non-zero since the method is public. Otherwise it counts newlines before the start of the actual text in range.