### PR TITLE
Fix syntax highlighting for short and Short types

### DIFF
--- a/java/keywords.txt
+++ b/java/keywords.txt
@@ -239,7 +239,6 @@ Float	KEYWORD5
 Integer	KEYWORD5
 HashMap	KEYWORD5	HashMap
 PrintWriter	KEYWORD5	PrintWriter
-Short	KEYWORD5	Short
 String	KEYWORD5	String
 StringBuffer	KEYWORD5
 StringBuilder	KEYWORD5

--- a/java/keywords.txt
+++ b/java/keywords.txt
@@ -239,6 +239,7 @@ Float	KEYWORD5
 Integer	KEYWORD5
 HashMap	KEYWORD5	HashMap
 PrintWriter	KEYWORD5	PrintWriter
+Short	KEYWORD5	Short
 String	KEYWORD5	String
 StringBuffer	KEYWORD5
 StringBuilder	KEYWORD5
@@ -251,6 +252,7 @@ double	KEYWORD5	double
 float	KEYWORD5	float
 int	KEYWORD5	int
 long	KEYWORD5	long
+short	KEYWORD5	short
 var	KEYWORD5
 
 


### PR DESCRIPTION
Resolves: #1259 
Changes:
- keywords.txt: register `short` and `Short` keywords so they're correctly highlighted as datatypes.

Tests: I don't think they apply here, but it looks and runs right for me.
<img width="1155" height="990" alt="image" src="https://github.com/user-attachments/assets/6f5ab7d7-e41c-4326-99d9-2b1cd51edd4a" />