### PR TITLE
Update legacy and active libraries in build script

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -68,7 +68,7 @@ tasks.register<Copy>("copyCore"){
     into(coreProject.layout.projectDirectory.dir("library"))
 }
 
-val legacyLibraries = arrayOf("dxf","io","net","serial","svg")
+val legacyLibraries = arrayOf("io","net","svg")
 legacyLibraries.forEach { library ->
     tasks.register<Copy>("library-$library-extraResources"){
         val build = project(":java:libraries:$library").tasks.named("build")
@@ -87,7 +87,7 @@ legacyLibraries.forEach { library ->
     }
 }
 
-val libraries = arrayOf("dxf", "pdf")
+val libraries = arrayOf("dxf", "pdf", "serial")
 
 libraries.forEach { library ->
     val name = "create-$library-library"


### PR DESCRIPTION
Removed 'dxf' and 'serial' from legacyLibraries and added 'serial' to active libraries in build.gradle.kts. This reflects changes in library maintenance and build configuration.

Closes #1264 
Closes #1262 
Closes #1273 