### PR TITLE
Fix signing property check in build script

### DIFF
--- a/java/preprocessor/build.gradle.kts
+++ b/java/preprocessor/build.gradle.kts
@@ -50,7 +50,7 @@ mavenPublishing{
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
     // Only sign if signing is set up
-    if(project.hasProperty("signing.keyId") || project.hasProperty("signing.signingInMemoryKey"))
+    if(project.hasProperty("signing.keyId") || project.hasProperty("signingInMemoryKey"))
         signAllPublications()
 
     pom{


### PR DESCRIPTION
Corrects the property name from 'signing.signingInMemoryKey' to 'signingInMemoryKey' in the signing condition to ensure proper detection of signing configuration.

Verified with a release on my personal repo https://github.com/Stefterv/processing4/releases/tag/processing-1423-4.4.124