### PR TITLE
Rename output JARs in createLibrary tasks

### DIFF
--- a/java/libraries/dxf/build.gradle.kts
+++ b/java/libraries/dxf/build.gradle.kts
@@ -35,5 +35,6 @@ tasks.register<Copy>("createLibrary"){
 
     from(tasks.jar) {
         into("library")
+        rename { "dxf.jar" }
     }
 }

--- a/java/libraries/pdf/build.gradle.kts
+++ b/java/libraries/pdf/build.gradle.kts
@@ -35,5 +35,6 @@ tasks.register<Copy>("createLibrary"){
 
     from(tasks.jar) {
         into("library")
+        rename { "pdf.jar" }
     }
 }

--- a/java/libraries/serial/build.gradle.kts
+++ b/java/libraries/serial/build.gradle.kts
@@ -32,5 +32,6 @@ tasks.register<Copy>("createLibrary") {
     }
     from(tasks.jar) {
         into("library")
+        rename { "serial.jar" }
     }
 }


### PR DESCRIPTION
The createLibrary tasks in dxf, pdf, and serial modules now rename the output JAR files to dxf.jar, pdf.jar, and serial.jar respectively as Processing does not expect the version name to be in the library jar