### PR TITLE
 Fix ArrayIndexOutOfBoundsException with compact SVG arc notation

### DIFF
--- a/core/src/processing/core/PShapeSVG.java
+++ b/core/src/processing/core/PShapeSVG.java
@@ -972,20 +972,31 @@ public class PShapeSVG extends PShape {
         if (isCompactArcNotation(token4)) {
           fa = token4.charAt(0) == '1';
           fs = token4.charAt(1) == '1';
+          // Case: flags and x-coordinate are concatenated (e.g. "01100")
+          // token4 contains flags + x, so y is at i+5. 
+          // We consume 2 fewer tokens than standard (8-2=6).
           if (token4.length() > 2) {
             endX = PApplet.parseFloat(token4.substring(2));
             endY = PApplet.parseFloat(pathTokens[i + 5]);
             tokenOffset = -2;
           } else {
+            // Case: flags are concatenated but separated from x (e.g. "01 100")
+            // token4 is flags, x is at i+5, y is at i+6.
+            // We consume 1 fewer token than standard (8-1=7).
             endX = PApplet.parseFloat(pathTokens[i + 5]);
             endY = PApplet.parseFloat(pathTokens[i + 6]);
             tokenOffset = -1;
           }
         } else {
+          // Standard notation: flags and coordinates are separate tokens.
+          // The 'A' command takes 7 arguments:
+          // rx, ry, x-axis-rotation, large-arc-flag, sweep-flag, x, y
+          // Here, we've already parsed rx (i+1), ry (i+2), and angle (i+3).
+          // token4 (i+4) is the large-arc-flag.
           fa = PApplet.parseFloat(token4) != 0;
-          fs = PApplet.parseFloat(pathTokens[i + 5]) != 0;
-          endX = PApplet.parseFloat(pathTokens[i + 6]);
-          endY = PApplet.parseFloat(pathTokens[i + 7]);
+          fs = PApplet.parseFloat(pathTokens[i + 5]) != 0; // sweep-flag
+          endX = PApplet.parseFloat(pathTokens[i + 6]);    // x
+          endY = PApplet.parseFloat(pathTokens[i + 7]);    // y
         }
         parsePathArcto(cx, cy, rx, ry, angle, fa, fs, endX, endY);
         cx = endX;
@@ -1009,20 +1020,27 @@ public class PShapeSVG extends PShape {
         if (isCompactArcNotation(token4)) {
           fa = token4.charAt(0) == '1';
           fs = token4.charAt(1) == '1';
+          // Case: flags and x-coordinate are concatenated
           if (token4.length() > 2) {
             endX = cx + PApplet.parseFloat(token4.substring(2));
             endY = cy + PApplet.parseFloat(pathTokens[i + 5]);
             tokenOffset = -2;
           } else {
+            // Case: flags are concatenated but separated from x
             endX = cx + PApplet.parseFloat(pathTokens[i + 5]);
             endY = cy + PApplet.parseFloat(pathTokens[i + 6]);
             tokenOffset = -1;
           }
         } else {
+          // Standard notation: flags and coordinates are separate tokens.
+          // The 'a' command takes 7 arguments:
+          // rx, ry, x-axis-rotation, large-arc-flag, sweep-flag, x, y
+          // Here, we've already parsed rx (i+1), ry (i+2), and angle (i+3).
+          // token4 (i+4) is the large-arc-flag.
           fa = PApplet.parseFloat(token4) != 0;
-          fs = PApplet.parseFloat(pathTokens[i + 5]) != 0;
-          endX = cx + PApplet.parseFloat(pathTokens[i + 6]);
-          endY = cy + PApplet.parseFloat(pathTokens[i + 7]);
+          fs = PApplet.parseFloat(pathTokens[i + 5]) != 0; // sweep-flag
+          endX = cx + PApplet.parseFloat(pathTokens[i + 6]); // x
+          endY = cy + PApplet.parseFloat(pathTokens[i + 7]); // y
         }
         parsePathArcto(cx, cy, rx, ry, angle, fa, fs, endX, endY);
         cx = endX;
@@ -1108,9 +1126,13 @@ public class PShapeSVG extends PShape {
       return false;
     }
     return token.length() > 1 &&
+           // First two characters must be '0' or '1' (flags)
            (token.charAt(0) == '0' || token.charAt(0) == '1') &&
            (token.charAt(1) == '0' || token.charAt(1) == '1') &&
+           // Either it's just the flags (length 2),
            (token.length() == 2 ||
+            // Or the flags are followed by the start of a number coordinate
+            // (digit, sign, or decimal point)
             (token.length() > 2 && (
               Character.isDigit(token.charAt(2)) ||
               token.charAt(2) == '+' ||

--- a/core/src/processing/core/PShapeSVG.java
+++ b/core/src/processing/core/PShapeSVG.java
@@ -961,14 +961,36 @@ public class PShapeSVG extends PShape {
         float rx = PApplet.parseFloat(pathTokens[i + 1]);
         float ry = PApplet.parseFloat(pathTokens[i + 2]);
         float angle = PApplet.parseFloat(pathTokens[i + 3]);
-        boolean fa = PApplet.parseFloat(pathTokens[i + 4]) != 0;
-        boolean fs = PApplet.parseFloat(pathTokens[i + 5]) != 0;
-        float endX = PApplet.parseFloat(pathTokens[i + 6]);
-        float endY = PApplet.parseFloat(pathTokens[i + 7]);
+        // In compact arc notation, flags and coordinates may be concatenated.
+        // e.g. "013" is parsed as large-arc=0, sweep=1, x=3
+        String token4 = pathTokens[i + 4];
+        boolean fa;
+        boolean fs;
+        float endX;
+        float endY;
+        int tokenOffset = 0;
+        if (isCompactArcNotation(token4)) {
+          fa = token4.charAt(0) == '1';
+          fs = token4.charAt(1) == '1';
+          if (token4.length() > 2) {
+            endX = PApplet.parseFloat(token4.substring(2));
+            endY = PApplet.parseFloat(pathTokens[i + 5]);
+            tokenOffset = -2;
+          } else {
+            endX = PApplet.parseFloat(pathTokens[i + 5]);
+            endY = PApplet.parseFloat(pathTokens[i + 6]);
+            tokenOffset = -1;
+          }
+        } else {
+          fa = PApplet.parseFloat(token4) != 0;
+          fs = PApplet.parseFloat(pathTokens[i + 5]) != 0;
+          endX = PApplet.parseFloat(pathTokens[i + 6]);
+          endY = PApplet.parseFloat(pathTokens[i + 7]);
+        }
         parsePathArcto(cx, cy, rx, ry, angle, fa, fs, endX, endY);
         cx = endX;
         cy = endY;
-        i += 8;
+        i += 8 + tokenOffset;
         prevCurve = true;
       }
       break;
@@ -978,14 +1000,34 @@ public class PShapeSVG extends PShape {
         float rx = PApplet.parseFloat(pathTokens[i + 1]);
         float ry = PApplet.parseFloat(pathTokens[i + 2]);
         float angle = PApplet.parseFloat(pathTokens[i + 3]);
-        boolean fa = PApplet.parseFloat(pathTokens[i + 4]) != 0;
-        boolean fs = PApplet.parseFloat(pathTokens[i + 5]) != 0;
-        float endX = cx + PApplet.parseFloat(pathTokens[i + 6]);
-        float endY = cy + PApplet.parseFloat(pathTokens[i + 7]);
+        String token4 = pathTokens[i + 4];
+        boolean fa;
+        boolean fs;
+        float endX;
+        float endY;
+        int tokenOffset = 0;
+        if (isCompactArcNotation(token4)) {
+          fa = token4.charAt(0) == '1';
+          fs = token4.charAt(1) == '1';
+          if (token4.length() > 2) {
+            endX = cx + PApplet.parseFloat(token4.substring(2));
+            endY = cy + PApplet.parseFloat(pathTokens[i + 5]);
+            tokenOffset = -2;
+          } else {
+            endX = cx + PApplet.parseFloat(pathTokens[i + 5]);
+            endY = cy + PApplet.parseFloat(pathTokens[i + 6]);
+            tokenOffset = -1;
+          }
+        } else {
+          fa = PApplet.parseFloat(token4) != 0;
+          fs = PApplet.parseFloat(pathTokens[i + 5]) != 0;
+          endX = cx + PApplet.parseFloat(pathTokens[i + 6]);
+          endY = cy + PApplet.parseFloat(pathTokens[i + 7]);
+        }
         parsePathArcto(cx, cy, rx, ry, angle, fa, fs, endX, endY);
         cx = endX;
         cy = endY;
-        i += 8;
+        i += 8 + tokenOffset;
         prevCurve = true;
       }
       break;
@@ -1051,6 +1093,29 @@ public class PShapeSVG extends PShape {
     }
     parsePathCode(VERTEX);
     parsePathVertex(px, py);
+  }
+
+
+  /**
+   * Checks if a token represents compact arc notation where flags and coordinates
+   * are concatenated (e.g., "013" for large-arc=0, sweep=1, x=3).
+   * 
+   * @param token the token to check
+   * @return true if the token is in compact arc notation format
+   */
+  private boolean isCompactArcNotation(String token) {
+    if (token == null) {
+      return false;
+    }
+    return token.length() > 1 &&
+           (token.charAt(0) == '0' || token.charAt(0) == '1') &&
+           (token.charAt(1) == '0' || token.charAt(1) == '1') &&
+           (token.length() == 2 ||
+            (token.length() > 2 && (
+              Character.isDigit(token.charAt(2)) ||
+              token.charAt(2) == '+' ||
+              token.charAt(2) == '-' ||
+              token.charAt(2) == '.')));
   }
 
 

--- a/core/test/processing/core/PShapeSVGPathTest.java
+++ b/core/test/processing/core/PShapeSVGPathTest.java
@@ -1,0 +1,79 @@
+package processing.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+import processing.data.XML;
+
+public class PShapeSVGPathTest {
+
+  @Test
+  public void testCompactPathNotation() {
+    // Test the failing SVG from issue #1244
+    String svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.0\" viewBox=\"0 0 29 29\">" +
+      "<path d=\"m0 6 3-2 15 4 7-7a2 2 0 013 3l-7 7 4 15-2 3-7-13-5 5v4l-2 2-2-5-5-2 2-2h4l5-5z\"/>" +
+      "</svg>";
+    
+    try {
+      XML xml = XML.parse(svgContent);
+      PShapeSVG shape = new PShapeSVG(xml);
+      Assert.assertNotNull(shape);
+    } catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+  }
+  
+  @Test
+  public void testWorkingPathNotation() {
+    // Test the working SVG (with explicit decimal points)
+    String svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.0\" viewBox=\"0 0 29 29\">" +
+      "<path d=\"m 0,5.9994379 2.9997,-1.9998 14.9985,3.9996 6.9993,-6.99930004 a 2.1211082,2.1211082 0 0 1 2.9997,2.99970004 l -6.9993,6.9993001 3.9996,14.9985 -1.9998,2.9997 -6.9993,-12.9987 -4.9995,4.9995 v 3.9996 l -1.9998,1.9998 -1.9998,-4.9995 -4.9995,-1.9998 1.9998,-1.9998 h 3.9996 l 4.9995,-4.9995 z\"/>" +
+      "</svg>";
+    
+    try {
+      XML xml = XML.parse(svgContent);
+      PShapeSVG shape = new PShapeSVG(xml);
+      Assert.assertNotNull(shape);
+    } catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+  }
+  
+  @Test
+  public void testCompactArcNotationVariations() {
+    // Test various compact arc notations
+    String[] testCases = {
+      // Flags only concatenated (e.g., "01")
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><path d=\"M10 10 A30 30 0 0110 50\"/></svg>",
+      // Flags and coordinate concatenated (e.g., "013")
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><path d=\"M10 10 A30 30 0 013 50\"/></svg>",
+      // Standard notation (should still work)
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><path d=\"M10 10 A30 30 0 0 1 10 50\"/></svg>"
+    };
+    
+    try {
+      for (String svgContent : testCases) {
+        XML xml = XML.parse(svgContent);
+        PShapeSVG shape = new PShapeSVG(xml);
+        Assert.assertNotNull(shape);
+      }
+    } catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+  }
+  
+  @Test
+  public void testCompactArcWithNegativeCoordinates() {
+    // Test compact arc notation with negative coordinates
+    String svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">" +
+      "<path d=\"M50 50 a20 20 0 01-10 20\"/>" +
+      "</svg>";
+    
+    try {
+      XML xml = XML.parse(svgContent);
+      PShapeSVG shape = new PShapeSVG(xml);
+      Assert.assertNotNull(shape);
+    } catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+  }
+}

--- a/core/test/processing/core/PShapeSVGPathTest.java
+++ b/core/test/processing/core/PShapeSVGPathTest.java
@@ -8,7 +8,6 @@ public class PShapeSVGPathTest {
 
   @Test
   public void testCompactPathNotation() {
-    // Test the failing SVG from issue #1244
     String svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.0\" viewBox=\"0 0 29 29\">" +
       "<path d=\"m0 6 3-2 15 4 7-7a2 2 0 013 3l-7 7 4 15-2 3-7-13-5 5v4l-2 2-2-5-5-2 2-2h4l5-5z\"/>" +
       "</svg>";
@@ -17,6 +16,11 @@ public class PShapeSVGPathTest {
       XML xml = XML.parse(svgContent);
       PShapeSVG shape = new PShapeSVG(xml);
       Assert.assertNotNull(shape);
+      Assert.assertTrue(shape.getChildCount() > 0);
+      
+      PShape path = shape.getChild(0);
+      Assert.assertNotNull(path);
+      Assert.assertTrue(path.getVertexCount() > 5);
     } catch (Exception e) {
       Assert.fail("Encountered exception " + e);
     }
@@ -40,22 +44,47 @@ public class PShapeSVGPathTest {
   
   @Test
   public void testCompactArcNotationVariations() {
-    // Test various compact arc notations
-    String[] testCases = {
-      // Flags only concatenated (e.g., "01")
-      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><path d=\"M10 10 A30 30 0 0110 50\"/></svg>",
-      // Flags and coordinate concatenated (e.g., "013")
-      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><path d=\"M10 10 A30 30 0 013 50\"/></svg>",
-      // Standard notation (should still work)
-      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\"><path d=\"M10 10 A30 30 0 0 1 10 50\"/></svg>"
-    };
+    String svgContent1 = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">" +
+      "<path d=\"M10 10 A30 30 0 013 50\"/></svg>";
     
     try {
-      for (String svgContent : testCases) {
-        XML xml = XML.parse(svgContent);
-        PShapeSVG shape = new PShapeSVG(xml);
-        Assert.assertNotNull(shape);
-      }
+      XML xml = XML.parse(svgContent1);
+      PShapeSVG shape = new PShapeSVG(xml);
+      PShape path = shape.getChild(0);
+      int vertexCount = path.getVertexCount();
+      PVector lastVertex = path.getVertex(vertexCount - 1);
+      Assert.assertEquals(3.0f, lastVertex.x, 0.0001f);
+      Assert.assertEquals(50.0f, lastVertex.y, 0.0001f);
+    } catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+    
+    String svgContent2 = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">" +
+      "<path d=\"M10 10 A30 30 0 0110 50\"/></svg>";
+    
+    try {
+      XML xml = XML.parse(svgContent2);
+      PShapeSVG shape = new PShapeSVG(xml);
+      PShape path = shape.getChild(0);
+      int vertexCount = path.getVertexCount();
+      PVector lastVertex = path.getVertex(vertexCount - 1);
+      Assert.assertEquals(10.0f, lastVertex.x, 0.0001f);
+      Assert.assertEquals(50.0f, lastVertex.y, 0.0001f);
+    } catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+    
+    String svgContent3 = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">" +
+      "<path d=\"M10 10 A30 30 0 0 1 10 50\"/></svg>";
+    
+    try {
+      XML xml = XML.parse(svgContent3);
+      PShapeSVG shape = new PShapeSVG(xml);
+      PShape path = shape.getChild(0);
+      int vertexCount = path.getVertexCount();
+      PVector lastVertex = path.getVertex(vertexCount - 1);
+      Assert.assertEquals(10.0f, lastVertex.x, 0.0001f);
+      Assert.assertEquals(50.0f, lastVertex.y, 0.0001f);
     } catch (Exception e) {
       Assert.fail("Encountered exception " + e);
     }
@@ -63,15 +92,17 @@ public class PShapeSVGPathTest {
   
   @Test
   public void testCompactArcWithNegativeCoordinates() {
-    // Test compact arc notation with negative coordinates
     String svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">" +
-      "<path d=\"M50 50 a20 20 0 01-10 20\"/>" +
-      "</svg>";
+      "<path d=\"M50 50 a20 20 0 01-10 20\"/></svg>";
     
     try {
       XML xml = XML.parse(svgContent);
       PShapeSVG shape = new PShapeSVG(xml);
-      Assert.assertNotNull(shape);
+      PShape path = shape.getChild(0);
+      int vertexCount = path.getVertexCount();
+      PVector lastVertex = path.getVertex(vertexCount - 1);
+      Assert.assertEquals(40.0f, lastVertex.x, 0.0001f);
+      Assert.assertEquals(70.0f, lastVertex.y, 0.0001f);
     } catch (Exception e) {
       Assert.fail("Encountered exception " + e);
     }


### PR DESCRIPTION
Fixes #1244

## Summary

Adds support for compact SVG arc notation where flags and coordinates are concatenated (e.g., `a2 2 0 013 3` instead of `a 2 2 0 0 1 3 3`). Previously crashed with `ArrayIndexOutOfBoundsException`.

## Changes

- **`core/src/processing/core/PShapeSVG.java`**: Added `isCompactArcNotation()` helper method to detect and parse concatenated arc flags/coordinates for both `A` and `a` commands
- **`core/test/processing/core/PShapeSVGPathTest.java`**: Added 4 test cases covering compact notation, standard notation, and edge cases


## Before


https://github.com/user-attachments/assets/d16fd9f4-f660-4332-81b3-4874a5266df3



## After

https://github.com/user-attachments/assets/0f5de7c3-d813-4b29-895b-c75e5909efc5




