### PR TITLE
Fix duplicate include for app:utils module

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ include(
     "core",
     "core:examples",
     "app",
+    "app:utils",
     "java",
     "java:preprocessor",
     "java:libraries:dxf",
@@ -12,4 +13,3 @@ include(
     "java:libraries:serial",
     "java:libraries:svg",
 )
-include("app:utils")


### PR DESCRIPTION
Removed redundant 'include("app:utils")' statement and added 'app:utils' to the main include block for consistency.