### PR TITLE
Enable automatic release for Maven Central publishing

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
 }
 
 mavenPublishing{
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
     signAllPublications()
 
     pom{

--- a/java/preprocessor/build.gradle.kts
+++ b/java/preprocessor/build.gradle.kts
@@ -47,7 +47,7 @@ publishing{
 }
 
 mavenPublishing{
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
     // Only sign if signing is set up
     if(project.hasProperty("signing.keyId") || project.hasProperty("signingInMemoryKey"))


### PR DESCRIPTION
Sets 'automaticRelease' to true in the publishToMavenCentral configuration to automate the release process when publishing to Maven Central.

Related to https://github.com/processing/processing4/issues/1281#issuecomment-3407436159