### PR TITLE
Migration of the `svg` library to Gradle

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -68,7 +68,7 @@ tasks.register<Copy>("copyCore"){
     into(coreProject.layout.projectDirectory.dir("library"))
 }
 
-val legacyLibraries = arrayOf("io","net","svg")
+val legacyLibraries = arrayOf("io","net")
 legacyLibraries.forEach { library ->
     tasks.register<Copy>("library-$library-extraResources"){
         val build = project(":java:libraries:$library").tasks.named("build")
@@ -87,7 +87,7 @@ legacyLibraries.forEach { library ->
     }
 }
 
-val libraries = arrayOf("dxf", "pdf", "serial")
+val libraries = arrayOf("dxf", "pdf", "serial", "svg")
 
 libraries.forEach { library ->
     val name = "create-$library-library"

--- a/java/libraries/svg/build.gradle.kts
+++ b/java/libraries/svg/build.gradle.kts
@@ -1,1 +1,40 @@
-ant.importBuild("build.xml")
+plugins {
+    java
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs("src")
+        }
+    }
+}
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(project(":core"))
+
+    implementation("org.apache.xmlgraphics:batik-all:1.19")
+}
+
+tasks.register<Copy>("createLibrary") {
+    dependsOn("jar")
+    into(layout.buildDirectory.dir("library"))
+
+    from(layout.projectDirectory) {
+        include("library.properties")
+        include("examples/**")
+    }
+
+    from(configurations.runtimeClasspath) {
+        into("library")
+    }
+
+    from(tasks.jar) {
+        into("library")
+        rename { "svg.jar" }
+    }
+}
+


### PR DESCRIPTION
## Resolve Issue
https://github.com/processing/processing4/issues/1098

## Description
Migrated the svg library from Ant-based build.xml to Gradle build.gradle.kts
## Changes
- Added Gradle build logic using Kotlin DSL in /java/libraries/svg/build.gradle.kts 
- modifies in java/build.gradle.kts
   ```gradle
   val libraries = arrayOf("dxf", "pdf", "serial", "svg")
   ```
   and 
   ```gradle
   val legacyLibraries = arrayOf("io","net")
   ```

