### PR TITLE
Add SVG export examples for various scenarios

### DIFF
--- a/java/libraries/dxf/examples/SimpleExport/SimpleExport.pde
+++ b/java/libraries/dxf/examples/SimpleExport/SimpleExport.pde
@@ -7,7 +7,7 @@
 
 
 import processing.dxf.*;
-boolean record = false;
+boolean isRecording = false;
 
 void setup() {
   size(400, 400, P3D);
@@ -16,7 +16,7 @@ void setup() {
 }
 
 void draw() {
-  if (record == true) {
+  if (isRecording == true) {
     beginRaw(DXF, "output.dxf"); // Start recording to the file
   }
   lights();
@@ -34,15 +34,15 @@ void draw() {
       }
     }
   }
-  if (record == true) {
+  if (isRecording == true) {
     endRaw();
-    record = false; // Stop recording to the file
+    isRecording = false; // Stop recording to the file
   }
 }
 
 void keyPressed() {
   if (key == 'R' || key == 'r') { // Press R to save the file
-    record = true;
+    isRecording = true;
   }
 }
 

--- a/java/libraries/dxf/src/processing/dxf/RawDXF.java
+++ b/java/libraries/dxf/src/processing/dxf/RawDXF.java
@@ -42,7 +42,7 @@ import processing.core.*;
  * <PRE>
  * import processing.dxf.*;
  *
- * boolean record;
+ * boolean isRecording;
  *
  * void setup() {
  *   size(500, 500, P3D);
@@ -50,19 +50,19 @@ import processing.core.*;
  *
  * void keyPressed() {
  *   // use a key press so that it doesn't make a million files
- *   if (key == 'r') record = true;
+ *   if (key == 'r') isRecording = true;
  * }
  *
  * void draw() {
- *   if (record) {
+ *   if (isRecording) {
  *     beginRaw(DXF, "output.dxf");
  *   }
  *
  *   // do all your drawing here
  *
- *   if (record) {
+ *   if (isRecording) {
  *     endRaw();
- *     record = false;
+ *     isRecording = false;
  *   }
  * }
  * </PRE>
@@ -70,7 +70,7 @@ import processing.core.*;
  * <PRE>
  * import processing.dxf.*;
  *
- * boolean record;
+ * boolean isRecording;
  * RawDXF dxf;
  *
  * void setup() {
@@ -79,25 +79,25 @@ import processing.core.*;
  *
  * void keyPressed() {
  *   // use a key press so that it doesn't make a million files
- *   if (key == 'r') record = true;
+ *   if (key == 'r') isRecording = true;
  * }
  *
  * void draw() {
- *   if (record) {
+ *   if (isRecording) {
  *     dxf = (RawDXF) createGraphics(width, height, DXF, "output.dxf");
  *     beginRaw(dxf);
  *   }
  *
  *   // do all your drawing here, and to set the layer, call:
- *   // if (record) {
+ *   // if (isRecording) {
  *   //   dxf.setLayer(num);
  *   // }
  *   // where 'num' is an integer.
  *   // the default is zero, or you can set it to whatever.
  *
- *   if (record) {
+ *   if (isRecording) {
  *     endRaw();
- *     record = false;
+ *     isRecording = false;
  *     dxf = null;
  *   }
  * }

--- a/java/libraries/svg/examples/NoScreenDisplay/NoScreenDisplay.pde
+++ b/java/libraries/svg/examples/NoScreenDisplay/NoScreenDisplay.pde
@@ -1,0 +1,23 @@
+/**
+ * SVG Export (No Screen Display)
+ * 
+ * This example draws a single frame to a SVG file and quits. 
+ * (Note that no display window will open; this helps when you're 
+ * trying to create massive SVG images that are far larger than 
+ * the screen size.)
+ */
+
+import processing.svg.*;
+
+void setup() {
+  size(400, 400, SVG, "filename.svg");
+}
+
+void draw() {
+  // Draw something good here
+  line(0, 0, width/2, height);
+
+  // Exit the program
+  println("Finished.");
+  exit();
+}

--- a/java/libraries/svg/examples/SingleFrameFromAnimation/SingleFrameFromAnimation.pde
+++ b/java/libraries/svg/examples/SingleFrameFromAnimation/SingleFrameFromAnimation.pde
@@ -1,0 +1,36 @@
+/**
+ * Single Frame from an Animation (With Screen Display)
+ * 
+ * It's also possible to save one frame from a program with 
+ * moving elements. Create a boolean variable to turn the SVG 
+ * recording process on and off.
+ */
+
+import processing.svg.*;
+
+boolean record;
+
+void setup() {
+  size(400, 400);
+}
+
+void draw() {
+  if (record) {
+    // Note that #### will be replaced with the frame number. Fancy!
+    beginRecord(SVG, "frame-####.svg");
+  }
+
+  // Draw something good here
+  background(255);
+  line(mouseX, mouseY, width/2, height/2);
+
+  if (record) {
+    endRecord();
+    record = false;
+  }
+}
+
+// Use a mouse press so thousands of files aren't created
+void mousePressed() {
+  record = true;
+}

--- a/java/libraries/svg/examples/SingleFrameFromAnimation/SingleFrameFromAnimation.pde
+++ b/java/libraries/svg/examples/SingleFrameFromAnimation/SingleFrameFromAnimation.pde
@@ -8,14 +8,14 @@
 
 import processing.svg.*;
 
-boolean record;
+boolean isRecording;
 
 void setup() {
   size(400, 400);
 }
 
 void draw() {
-  if (record) {
+  if (isRecording) {
     // Note that #### will be replaced with the frame number. Fancy!
     beginRecord(SVG, "frame-####.svg");
   }
@@ -24,13 +24,13 @@ void draw() {
   background(255);
   line(mouseX, mouseY, width/2, height/2);
 
-  if (record) {
+  if (isRecording) {
     endRecord();
-    record = false;
+    isRecording = false;
   }
 }
 
 // Use a mouse press so thousands of files aren't created
 void mousePressed() {
-  record = true;
+  isRecording = true;
 }

--- a/java/libraries/svg/examples/ThreeDGeometry/ThreeDGeometry.pde
+++ b/java/libraries/svg/examples/ThreeDGeometry/ThreeDGeometry.pde
@@ -1,0 +1,49 @@
+/**
+ * SVG Files from 3D Geometry (With Screen Display)
+ * 
+ * To create vectors from 3D data, use the beginRaw() and 
+ * endRaw() commands. These commands will grab the shape data 
+ * just before it is rendered to the screen. At this stage, 
+ * your entire scene is nothing but a long list of lines and 
+ * triangles. This means that a shape created with sphere() 
+ * method will be made up of hundreds of triangles, rather 
+ * than a single object.
+ * 
+ * When using beginRaw() and endRaw(), it's possible to write 
+ * to either a 2D or 3D renderer. For instance, beginRaw() 
+ * with the SVG library will write the geometry as flattened 
+ * triangles and lines.
+ */
+
+import processing.svg.*;
+
+boolean record;
+
+void setup() {
+  size(500, 500, P3D);
+}
+
+void draw() {
+  if (record) {
+    beginRaw(SVG, "output.svg");
+  }
+
+  // Do all your drawing here
+  background(204);
+  translate(width/2, height/2, -200);
+  rotateZ(0.2);
+  rotateY(mouseX/500.0);
+  box(200);
+
+  if (record) {
+    endRaw();
+    record = false;
+  }
+}
+
+// Hit 'r' to record a single frame
+void keyPressed() {
+  if (key == 'r') {
+    record = true;
+  }
+}

--- a/java/libraries/svg/examples/ThreeDGeometry/ThreeDGeometry.pde
+++ b/java/libraries/svg/examples/ThreeDGeometry/ThreeDGeometry.pde
@@ -17,14 +17,14 @@
 
 import processing.svg.*;
 
-boolean record;
+boolean isRecording;
 
 void setup() {
   size(500, 500, P3D);
 }
 
 void draw() {
-  if (record) {
+  if (isRecording) {
     beginRaw(SVG, "output.svg");
   }
 
@@ -35,15 +35,15 @@ void draw() {
   rotateY(mouseX/500.0);
   box(200);
 
-  if (record) {
+  if (isRecording) {
     endRaw();
-    record = false;
+    isRecording = false;
   }
 }
 
 // Hit 'r' to record a single frame
 void keyPressed() {
   if (key == 'r') {
-    record = true;
+    isRecording = true;
   }
 }

--- a/java/libraries/svg/examples/UsingCreateGraphics/UsingCreateGraphics.pde
+++ b/java/libraries/svg/examples/UsingCreateGraphics/UsingCreateGraphics.pde
@@ -1,0 +1,17 @@
+/**
+ * Using createGraphics() to Create an SVG File
+ * 
+ * To write a SVG file using only the createGraphics() command, 
+ * rather than as part of a sketch, it's necessary to call 
+ * dispose() on the PGraphicsSVG object. This is the same as 
+ * calling exit(), but it won't quit the sketch.
+ */
+
+import processing.svg.*;
+
+PGraphics svg = createGraphics(300, 300, SVG, "output.svg");
+svg.beginDraw();
+svg.background(128, 0, 0);
+svg.line(50, 50, 250, 250);
+svg.dispose();
+svg.endDraw();

--- a/java/libraries/svg/examples/WithScreenDisplay/WithScreenDisplay.pde
+++ b/java/libraries/svg/examples/WithScreenDisplay/WithScreenDisplay.pde
@@ -1,0 +1,24 @@
+/**
+ * SVG Export (With Screen Display)
+ * 
+ * To draw to the screen while also saving an SVG, use the 
+ * beginRecord() and endRecord() functions. Unlike the PDF 
+ * renderer, the SVG renderer will only save the final frame 
+ * of a sequence. This is slower, but is useful when you need 
+ * to see what you're working on as it saves.
+ */
+
+import processing.svg.*;
+
+void setup() {
+  size(400, 400);
+  noLoop();
+  beginRecord(SVG, "filename.svg");
+}
+
+void draw() {
+  // Draw something good here
+  line(0, 0, width/2, height);
+
+  endRecord();
+}


### PR DESCRIPTION
## Description
Added 5 complete examples for the Processing SVG library based on the official reference documentation. These examples were previously listed on the Processing website but not bundled with the library.

## Changes
Created `examples` directory with 5 working examples:

1. **NoScreenDisplay** - Export SVG without opening a display window
2. **WithScreenDisplay** - Export SVG while displaying on screen using `beginRecord()`
3. **SingleFrameFromAnimation** - Capture a single frame from an animated sketch
4. **ThreeDGeometry** - Export 3D geometry as flattened SVG using `beginRaw()`
5. **UsingCreateGraphics** - Programmatically create SVG files using `createGraphics()`

## Closes
Fixes #1290