### PR TITLE
Refactor initialization to use background threads

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -23,6 +23,17 @@
 
 package processing.app;
 
+import java.awt.*;
+import java.awt.event.ActionListener;
+import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import java.util.List;
+import java.util.Map.Entry;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+
 import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.FlatLightLaf;
@@ -33,19 +44,6 @@ import processing.app.ui.*;
 import processing.app.ui.Toolkit;
 import processing.core.PApplet;
 import processing.data.StringList;
-
-import javax.swing.*;
-import javax.swing.tree.DefaultMutableTreeNode;
-import java.awt.*;
-import java.awt.event.ActionListener;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
-import java.util.List;
-import java.util.Map.Entry;
 
 /**
  * The base class for the main processing application.
@@ -231,7 +229,7 @@ public class Base {
         Messages.log("Base() constructor succeeded");
 
         // Prevent more than one copy of the PDE from running.
-        SingleInstance.startServer(base);
+        new Thread(() -> { SingleInstance.startServer(base); } ).start();
 
         handleWelcomeScreen(base);
         handleCrustyDisplay();
@@ -850,7 +848,7 @@ public class Base {
     return contribTools;
   }
 
-
+  private List<Tool> toolsToInit = new ArrayList<>();
   public void rebuildToolList() {
     // Only do these once because the list of internal tools will never change
     if (internalTools == null) {
@@ -870,43 +868,12 @@ public class Base {
     // Only init() these the first time they're loaded
     if (coreTools == null) {
       coreTools = ToolContribution.loadAll(Base.getToolsFolder());
-      for (Tool tool : coreTools) {
-        tool.init(this);
-      }
+      toolsToInit.addAll(coreTools);
     }
 
     // Reset the contributed tools and re-init() all of them.
     contribTools = ToolContribution.loadAll(Base.getSketchbookToolsFolder());
-    for (Tool tool : contribTools) {
-      try {
-        tool.init(this);
-
-        // With the exceptions, we can't call statusError because the window
-        // isn't completely set up yet. Also not gonna pop up a warning because
-        // people may still be running different versions of Processing.
-
-      } catch (VerifyError | AbstractMethodError ve) {
-        System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
-                           "compatible with this version of Processing");
-        Messages.err("Incompatible Tool found during tool.init()", ve);
-
-      } catch (NoSuchMethodError nsme) {
-        System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
-                           "compatible with this version of Processing");
-        System.err.println("The " + nsme.getMessage() + " method no longer exists.");
-        Messages.err("Incompatible Tool found during tool.init()", nsme);
-
-      } catch (NoClassDefFoundError ncdfe) {
-        System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
-                           "compatible with this version of Processing");
-        System.err.println("The " + ncdfe.getMessage() + " class is no longer available.");
-        Messages.err("Incompatible Tool found during tool.init()", ncdfe);
-
-      } catch (Error | Exception e) {
-        System.err.println("An error occurred inside \"" + tool.getMenuTitle() + "\"");
-        e.printStackTrace();
-      }
-    }
+    toolsToInit.addAll(contribTools);
   }
 
 
@@ -915,7 +882,7 @@ public class Base {
       final Tool tool = (Tool)
         toolClass.getDeclaredConstructor().newInstance();
 
-      tool.init(this);
+      toolsToInit.add(tool);
       internalTools.add(tool);
 
     } catch (Exception e) {
@@ -963,12 +930,40 @@ public class Base {
     toolsMenu.add(manageTools);
   }
 
+  void initTool(Tool tool) {
+    if(!toolsToInit.contains(tool)) {return;}
+    try {
+      tool.init(this);
+      toolsToInit.remove(tool);
+    } catch (VerifyError | AbstractMethodError ve) {
+      System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
+              "compatible with this version of Processing");
+      Messages.err("Incompatible Tool found during tool.init()", ve);
+
+    } catch (NoSuchMethodError nsme) {
+      System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
+              "compatible with this version of Processing");
+      System.err.println("The " + nsme.getMessage() + " method no longer exists.");
+      Messages.err("Incompatible Tool found during tool.init()", nsme);
+
+    } catch (NoClassDefFoundError ncdfe) {
+      System.err.println("\"" + tool.getMenuTitle() + "\" is not " +
+              "compatible with this version of Processing");
+      System.err.println("The " + ncdfe.getMessage() + " class is no longer available.");
+      Messages.err("Incompatible Tool found during tool.init()", ncdfe);
+
+    } catch (Error | Exception e) {
+      System.err.println("An error occurred inside \"" + tool.getMenuTitle() + "\"");
+      e.printStackTrace();
+    }
+  }
 
   JMenuItem createToolItem(final Tool tool) { //, Map<String, JMenuItem> toolItems) {
     String title = tool.getMenuTitle();
     final JMenuItem item = new JMenuItem(title);
     item.addActionListener(e -> {
       try {
+        initTool(tool);
         tool.run();
 
       } catch (NoSuchMethodError | NoClassDefFoundError ne) {

--- a/app/src/processing/app/platform/DefaultPlatform.java
+++ b/app/src/processing/app/platform/DefaultPlatform.java
@@ -23,6 +23,12 @@
 
 package processing.app.platform;
 
+import java.awt.*;
+import java.io.File;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.FlatLightLaf;
 import processing.app.Base;
@@ -31,10 +37,6 @@ import processing.app.ui.Toolkit;
 import processing.awt.ShimAWT;
 import processing.core.PApplet;
 
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import java.awt.*;
-import java.io.File;
 
 
 /**
@@ -110,18 +112,29 @@ public class DefaultPlatform {
     // (i.e. Nimbus on Linux) with our custom components is badness.
 
     // dummy font call so that it's registered for FlatLaf
-    Font defaultFont = Toolkit.getSansFont(14, Font.PLAIN);
-    UIManager.put("defaultFont", defaultFont);
+    new Thread(() -> {
+      Font defaultFont = Toolkit.getSansFont(14, Font.PLAIN);
+      UIManager.put("defaultFont", defaultFont);
+    }).start();
+
 
     // pull in FlatLaf.properties from the processing.app.laf folder
     FlatLaf.registerCustomDefaultsSource("processing.app.laf");
 
-    // start with Light, but updateTheme() will be called soon
-    UIManager.setLookAndFeel(new FlatLightLaf());
+    new Thread(() -> {
+      // start with Light, but updateTheme() will be called soon
+        try {
+            UIManager.setLookAndFeel(new FlatLightLaf());
+        } catch (UnsupportedLookAndFeelException e) {
+            throw new RuntimeException(e);
+        }
+    }).start();
 
     // Does not fully remove the gray hairline (probably from a parent
     // Window object), but is an improvement from the heavier default.
-    UIManager.put("ToolTip.border", new EmptyBorder(0, 0, 0, 0));
+    new Thread(() -> {
+      UIManager.put("ToolTip.border", new EmptyBorder(0, 0, 0, 0));
+    }).start();
 
     /*
     javax.swing.UIDefaults defaults = UIManager.getDefaults();

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -193,7 +193,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
     timer = new Timer();
 
-    buildMenuBar();
+    new Thread(this::buildMenuBar).start();
 
     JPanel contentPain = new JPanel();
     setContentPane(contentPain);

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -6822,28 +6822,9 @@ public class PApplet implements PConstants {
 
   static public String[] loadStrings(BufferedReader reader) {
     try {
-      String[] lines = new String[100];
-      int lineCount = 0;
-      String line;
-      while ((line = reader.readLine()) != null) {
-        if (lineCount == lines.length) {
-          String[] temp = new String[lineCount << 1];
-          System.arraycopy(lines, 0, temp, 0, lineCount);
-          lines = temp;
-        }
-        lines[lineCount++] = line;
-      }
+      var lines = reader.lines().toArray(String[]::new);
       reader.close();
-
-      if (lineCount == lines.length) {
-        return lines;
-      }
-
-      // resize array to appropriate amount for these lines
-      String[] output = new String[lineCount];
-      System.arraycopy(lines, 0, output, 0, lineCount);
-      return output;
-
+      return lines;
     } catch (IOException e) {
       e.printStackTrace();
       //throw new RuntimeException("Error inside loadStrings()");

--- a/java/src/processing/mode/java/JavaTextArea.java
+++ b/java/src/processing/mode/java/JavaTextArea.java
@@ -52,7 +52,9 @@ public class JavaTextArea extends PdeTextArea {
   public JavaTextArea(TextAreaDefaults defaults, JavaEditor editor) {
     super(defaults, new JavaInputHandler(editor), editor);
 
-    suggestionGenerator = new CompletionGenerator((JavaMode) editor.getMode());
+    new Thread(() -> {
+      suggestionGenerator = new CompletionGenerator((JavaMode) editor.getMode());
+    }).start();
     tweakMode = false;
   }
 

--- a/java/src/processing/mode/java/PreprocService.java
+++ b/java/src/processing/mode/java/PreprocService.java
@@ -80,7 +80,7 @@ public class PreprocService {
   protected final JavaMode javaMode;
   protected final Sketch sketch;
 
-  protected final ASTParser parser = ASTParser.newParser(AST.JLS11);
+  protected ASTParser parser;
 
   private final Thread preprocessingThread;
   private final BlockingQueue<Boolean> requestQueue = new ArrayBlockingQueue<>(1);
@@ -116,6 +116,9 @@ public class PreprocService {
    * The "main loop" for the background thread that checks for code issues.
    */
   private void mainLoop() {
+    if(parser == null) {
+      parser = ASTParser.newParser(AST.JLS11);
+    }
     running = true;
     PreprocSketch prevResult = null;
     CompletableFuture<?> runningCallbacks = null;

--- a/java/src/processing/mode/java/debug/Debugger.java
+++ b/java/src/processing/mode/java/debug/Debugger.java
@@ -112,7 +112,7 @@ public class Debugger {
 
   public Debugger(JavaEditor editor) {
     this.editor = editor;
-    inspector = new VariableInspector(editor);
+//    inspector = new VariableInspector(editor);
   }
 
 
@@ -207,6 +207,9 @@ public class Debugger {
     } else {
       debugItem.setText(Language.text("menu.debug.enable"));
     }
+    if(inspector == null) {
+      inspector = new VariableInspector(editor);
+    }
     inspector.setVisible(enabled);
 
     for (Component item : debugMenu.getMenuComponents()) {
@@ -298,6 +301,7 @@ public class Debugger {
 
 
   public void dispose() {
+    if(inspector == null) return;
     inspector.dispose();
   }
 


### PR DESCRIPTION
Moved several initialization tasks to background threads for improved startup performance and responsiveness, including tool, font, UI, and suggestion generator setup. Deferred some tool initialization until first use, added caching for SVG rendering, and simplified string loading in PApplet. Also made minor changes to library list and variable inspector initialization.

- [ ] Find a way to display the splash screen optionally as `Preferences` will not yet be initialised.


https://github.com/user-attachments/assets/6aec6398-0cfe-4628-8487-69c88f41bfc3

