### PR TITLE
Implement `background` method

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Install Wayland Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwayland-dev libxkbcommon-dev
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
@@ -66,6 +70,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           architecture: ${{ matrix.arch }}
+      - name: Install Wayland Dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwayland-dev libxkbcommon-dev
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/pull_request-gradle.yml
+++ b/.github/workflows/pull_request-gradle.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Install Wayland Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwayland-dev libxkbcommon-dev
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
@@ -67,6 +71,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           architecture: ${{ matrix.arch }}
+      - name: Install Wayland Dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwayland-dev libxkbcommon-dev
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 

--- a/core/src/processing/webgpu/PGraphicsWebGPU.java
+++ b/core/src/processing/webgpu/PGraphicsWebGPU.java
@@ -27,6 +27,12 @@ public class PGraphicsWebGPU extends PGraphics {
     }
 
     @Override
+    public void beginDraw() {
+        super.beginDraw();
+        checkSettings();
+    }
+
+    @Override
     public void endDraw() {
         super.endDraw();
         PWebGPU.update();
@@ -35,7 +41,18 @@ public class PGraphicsWebGPU extends PGraphics {
     @Override
     public void dispose() {
         super.dispose();
-
+        if (windowId != 0) {
+            PWebGPU.destroySurface(windowId);
+            windowId = 0;
+        }
         PWebGPU.exit();
+    }
+
+    @Override
+    protected void backgroundImpl() {
+        if (windowId == 0) {
+            return;
+        }
+        PWebGPU.backgroundColor(windowId, backgroundR, backgroundG, backgroundB, backgroundA);
     }
 }

--- a/core/src/processing/webgpu/PWebGPU.java
+++ b/core/src/processing/webgpu/PWebGPU.java
@@ -2,10 +2,12 @@ package processing.webgpu;
 
 import processing.core.NativeLibrary;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 import static java.lang.foreign.MemorySegment.NULL;
 import static processing.ffi.processing_h.*;
+import processing.ffi.Color;
 
 /**
  * PWebGPU provides the native interface layer for libProcessing's WebGPU support.
@@ -48,6 +50,16 @@ public class PWebGPU {
     }
 
     /**
+     * Destroys a WebGPU surface.
+     *
+     * @param windowId The window ID returned from createSurface
+     */
+    public static void destroySurface(long windowId) {
+        processing_destroy_surface(windowId);
+        checkError();
+    }
+
+    /**
      * Updates a window's size.
      *
      * @param windowId The window ID returned from createSurface
@@ -55,7 +67,7 @@ public class PWebGPU {
      * @param height New physical window height in pixels
      */
     public static void windowResized(long windowId, int width, int height) {
-        processing_window_resized(windowId, width, height);
+        processing_resize_surface(windowId, width, height);
         checkError();
     }
 
@@ -73,6 +85,20 @@ public class PWebGPU {
     public static void exit() {
         processing_exit((byte) 0);
         checkError();
+    }
+
+    public static void backgroundColor(long windowId, float r, float g, float b, float a) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment color = Color.allocate(arena);
+
+            Color.r(color, r);
+            Color.g(color, g);
+            Color.b(color, b);
+            Color.a(color, a);
+
+            processing_background_color(windowId, color);
+            checkError();
+        }
     }
 
     /**

--- a/libProcessing/Cargo.lock
+++ b/libProcessing/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
 name = "ffi"
 version = "0.1.0"
 dependencies = [
+ "bevy",
  "cbindgen",
  "renderer",
 ]

--- a/libProcessing/Cargo.toml
+++ b/libProcessing/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 resolver = "3"
 members = ["ffi","renderer"]
+
+[workspace.dependencies]
+bevy = { version = "0.17", no-default-features = true, features = [
+    "bevy_render",
+    "bevy_color",
+] }

--- a/libProcessing/ffi/Cargo.toml
+++ b/libProcessing/ffi/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 renderer = { path = "../renderer" }
+bevy = { workspace = true }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/libProcessing/ffi/src/color.rs
+++ b/libProcessing/ffi/src/color.rs
@@ -1,0 +1,14 @@
+/// A sRGB (?) color
+#[repr(C)]
+pub struct Color {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
+}
+
+impl From<Color> for bevy::color::Color {
+    fn from(color: Color) -> Self {
+        bevy::color::Color::srgba(color.r, color.g, color.b, color.a)
+    }
+}

--- a/libProcessing/ffi/src/lib.rs
+++ b/libProcessing/ffi/src/lib.rs
@@ -1,3 +1,7 @@
+use crate::color::Color;
+use bevy::prelude::Entity;
+
+mod color;
 mod error;
 
 /// Initialize libProcessing.
@@ -31,6 +35,19 @@ pub extern "C" fn processing_create_surface(
         .unwrap_or(0)
 }
 
+/// Destroy the surface associated with the given window ID.
+///
+/// SAFETY:
+/// - Init and create_surface have been called.
+/// - window_id is a valid ID returned from create_surface.
+/// - This is called from the same thread as init.
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_destroy_surface(window_id: u64) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| renderer::destroy_surface(window_entity));
+}
+
 /// Update window size when resized.
 ///
 /// SAFETY:
@@ -38,9 +55,21 @@ pub extern "C" fn processing_create_surface(
 /// - window_id is a valid ID returned from create_surface.
 /// - This is called from the same thread as init.
 #[unsafe(no_mangle)]
-pub extern "C" fn processing_window_resized(window_id: u64, width: u32, height: u32) {
+pub extern "C" fn processing_resize_surface(window_id: u64, width: u32, height: u32) {
     error::clear_error();
-    error::check(|| renderer::window_resized(window_id, width, height));
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| renderer::resize_surface(window_entity, width, height));
+}
+
+/// Set the background color for the given window.
+///
+/// SAFETY:
+/// - This is called from the same thread as init.
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_background_color(window_id: u64, color: Color) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| renderer::background_color(window_entity, color.into()));
 }
 
 /// Step the application forward.

--- a/libProcessing/renderer/Cargo.toml
+++ b/libProcessing/renderer/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2024"
 [dependencies]
 tracing = "0.1"
 tracing-subscriber = "0.3"
-bevy = { version = "0.17", no-default-features = true, features = [
-    "bevy_render"
-] }
+bevy = { workspace = true }
 thiserror = "2"
 raw-window-handle = "0.6"
 


### PR DESCRIPTION
Allows setting the background clear color in a sketch.

Changes:
- Adds a camera when spawning a window. Note that we also add a `RenderLayers` component, which we'll also need to attach to any geometry spawned to render in that window. This is just hygiene for eventual multi-window apps.
- Adds a simple `Color` FFI struct. We'll likely want to make this more complicated later or support all the color spaces that bevy does (even if processing doesn't). But this demonstrates how to do allocations on the Java side.

I didn't implement the `PImage` override here as that will require the actual renderer (i.e. not just a clear color). It's also possible the semantics here are wrong. I think processing may allow you to clear multiple times in a frame, which means drawing a fullscreen quad not setting the render pass clear. But we can follow up with that once more rendering infra is implemented.