### PR TITLE
Allow exported apps on windows to be run from anywhere on the system

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -997,7 +997,7 @@ public class JavaBuild {
       XML clazzPath = config.addChild("classPath");
       clazzPath.addChild("mainClass").setContent(sketch.getMainName());
       for (String jarName : jarList) {
-        clazzPath.addChild("cp").setContent("lib/" + jarName);
+        clazzPath.addChild("cp").setContent("%EXEDIR%/lib/" + jarName);
       }
       XML jre = config.addChild("jre");
       if (embedJava) {


### PR DESCRIPTION
On Linux and Macos an exported sketch can be run from any working directory. Until now that has not been the case on windows. This was caused by the EXEDIR environment variable not being used when forming the class path. This pr makes that simple change, allowing the executable generated from exporting a sketch to be executed on the command line from any working directory.