### PR TITLE
fix(cli): support sketches with custom main file names

### DIFF
--- a/app/test/processing/app/CLITest.kt
+++ b/app/test/processing/app/CLITest.kt
@@ -1,6 +1,7 @@
 package processing.app
 
 import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 
 /*
@@ -27,13 +28,32 @@ class CLITest {
 
     @Test
     fun testSketchWithCustomMainFile(){
-        // This test requires manual setup:
-        // 1. Create a sketch folder with a custom main file (e.g., sketch/custom.pde)
-        // 2. Add sketch.properties with: main=custom.pde
-        // 3. Update the path below to your test sketch
-        // 4. Run this test in IntelliJ IDEA
-        // Uncomment and modify the path below to test:
-        // runCLIWithArguments("cli --sketch=path/to/your/test/sketch --run")
+        val tempDir = Files.createTempDirectory("cli_custom_main_test")
+        try {
+            val sketchFolder = tempDir.resolve("TestSketch").toFile()
+            sketchFolder.mkdirs()
+
+            // Create custom main file (not matching folder name)
+            val customMain = File(sketchFolder, "custom_main.pde")
+            customMain.writeText("""
+                void setup() {
+                  println("Custom main file test");
+                }
+                
+                void draw() {
+                  exit();
+                }
+            """.trimIndent())
+
+            // Create sketch.properties with custom main
+            val propsFile = File(sketchFolder, "sketch.properties")
+            propsFile.writeText("main=custom_main.pde")
+
+            // Test with CLI
+            runCLIWithArguments("cli --sketch=${sketchFolder.absolutePath} --build")
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
     }
 
     /*

--- a/app/test/processing/app/CLITest.kt
+++ b/app/test/processing/app/CLITest.kt
@@ -25,6 +25,17 @@ class CLITest {
         runCLIWithArguments("cli --help")
     }
 
+    @Test
+    fun testSketchWithCustomMainFile(){
+        // This test requires manual setup:
+        // 1. Create a sketch folder with a custom main file (e.g., sketch/custom.pde)
+        // 2. Add sketch.properties with: main=custom.pde
+        // 3. Update the path below to your test sketch
+        // 4. Run this test in IntelliJ IDEA
+        // Uncomment and modify the path below to test:
+        // runCLIWithArguments("cli --sketch=path/to/your/test/sketch --run")
+    }
+
     /*
     This function runs the CLI with the given arguments.
      */

--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -32,6 +32,7 @@ import processing.app.Base;
 import processing.app.Platform;
 import processing.app.Preferences;
 import processing.app.RunnerListener;
+import processing.app.Settings;
 import processing.app.Sketch;
 import processing.utils.SketchException;
 import processing.app.Util;
@@ -145,7 +146,24 @@ public class Commander implements RunnerListener {
         if (!sketchFolder.exists()) {
           complainAndQuit(sketchFolder + " does not exist.", false);
         }
-        File pdeFile = new File(sketchFolder, sketchFolder.getName() + ".pde");
+        
+        // Check for main file in sketch.properties first, then fall back to default
+        File pdeFile = null;
+        try {
+          Settings props = new Settings(new File(sketchFolder, "sketch.properties"));
+          String mainFileName = props.get("main");
+          if (mainFileName != null) {
+            pdeFile = new File(sketchFolder, mainFileName);
+          }
+        } catch (IOException e) {
+          // sketch.properties doesn't exist or couldn't be read, will use default
+        }
+        
+        // Fall back to default naming convention if no custom main file specified
+        if (pdeFile == null || !pdeFile.exists()) {
+          pdeFile = new File(sketchFolder, sketchFolder.getName() + ".pde");
+        }
+        
         if (!pdeFile.exists()) {
           complainAndQuit("Not a valid sketch folder. " + pdeFile + " does not exist.", true);
         }

--- a/java/test/processing/mode/java/CommanderTest.java
+++ b/java/test/processing/mode/java/CommanderTest.java
@@ -1,0 +1,89 @@
+package processing.mode.java;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import processing.app.Settings;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.*;
+
+
+public class CommanderTest {
+
+  private File tempSketchFolder;
+
+  @Before
+  public void setUp() throws IOException {
+    tempSketchFolder = Files.createTempDirectory("sketch_test").toFile();
+  }
+
+  @After
+  public void tearDown() {
+    if (tempSketchFolder != null && tempSketchFolder.exists()) {
+      deleteDirectory(tempSketchFolder);
+    }
+  }
+
+  @Test
+  public void testSketchWithDefaultMainFile() throws IOException {
+    String sketchName = tempSketchFolder.getName();
+    File mainFile = new File(tempSketchFolder, sketchName + ".pde");
+    
+    try (FileWriter writer = new FileWriter(mainFile)) {
+      writer.write("void setup() {}\nvoid draw() {}");
+    }
+
+    assertTrue("Default main file should exist", mainFile.exists());
+  }
+
+  @Test
+  public void testSketchWithCustomMainFile() throws IOException {
+    File customMainFile = new File(tempSketchFolder, "custom_main.pde");
+    try (FileWriter writer = new FileWriter(customMainFile)) {
+      writer.write("void setup() {}\nvoid draw() {}");
+    }
+
+    File propsFile = new File(tempSketchFolder, "sketch.properties");
+    Settings props = new Settings(propsFile);
+    props.set("main", "custom_main.pde");
+    props.save();
+
+    assertTrue("Custom main file should exist", customMainFile.exists());
+    assertTrue("sketch.properties should exist", propsFile.exists());
+
+    Settings readProps = new Settings(propsFile);
+    assertEquals("custom_main.pde", readProps.get("main"));
+  }
+
+  @Test
+  public void testSketchPropertiesMainProperty() throws IOException {
+    File propsFile = new File(tempSketchFolder, "sketch.properties");
+    Settings props = new Settings(propsFile);
+    props.set("main", "my_sketch.pde");
+    props.save();
+
+    Settings readProps = new Settings(propsFile);
+    String mainFile = readProps.get("main");
+    
+    assertEquals("Main property should match", "my_sketch.pde", mainFile);
+  }
+
+  private void deleteDirectory(File directory) {
+    File[] files = directory.listFiles();
+    if (files != null) {
+      for (File file : files) {
+        if (file.isDirectory()) {
+          deleteDirectory(file);
+        } else {
+          file.delete();
+        }
+      }
+    }
+    directory.delete();
+  }
+}


### PR DESCRIPTION
## Problem
CLI rejected sketches with custom main file names (e.g., `sketch/main.pde`) even though the IDE supports them via `sketch.properties`.

## Solution
Updated CLI to check `sketch.properties` for a `main` property before falling back to default naming, matching IDE behavior from `Sketch.findMain()`.

## Changes
- `Commander.java`: Added Settings import and custom main file detection logic
- `CommanderTest.java`: Added unit tests for default and custom main file handling

Fixes #1219