### PR TITLE
Fix compose `Locale`

### DIFF
--- a/app/src/processing/app/ui/theme/Locale.kt
+++ b/app/src/processing/app/ui/theme/Locale.kt
@@ -3,7 +3,6 @@ package processing.app.ui.theme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
-import processing.app.LocalPreferences
 import processing.app.Messages
 import processing.app.Platform
 import processing.app.PlatformStart
@@ -15,10 +14,19 @@ import java.util.*
 class Locale(language: String = "") : Properties() {
     init {
         val locale = java.util.Locale.getDefault()
-        load(ClassLoader.getSystemResourceAsStream("PDE.properties"))
-        load(ClassLoader.getSystemResourceAsStream("PDE_${locale.language}.properties") ?: InputStream.nullInputStream())
-        load(ClassLoader.getSystemResourceAsStream("PDE_${locale.toLanguageTag()}.properties") ?: InputStream.nullInputStream())
-        load(ClassLoader.getSystemResourceAsStream("PDE_${language}.properties") ?: InputStream.nullInputStream())
+        load(ClassLoader.getSystemResourceAsStream("languages/PDE.properties"))
+        load(
+            ClassLoader.getSystemResourceAsStream("languages/PDE_${locale.language}.properties")
+                ?: InputStream.nullInputStream()
+        )
+        load(
+            ClassLoader.getSystemResourceAsStream("languages/PDE_${locale.toLanguageTag()}.properties")
+                ?: InputStream.nullInputStream()
+        )
+        load(
+            ClassLoader.getSystemResourceAsStream("languages/PDE_${language}.properties")
+                ?: InputStream.nullInputStream()
+        )
     }
 
     @Deprecated("Use get instead", ReplaceWith("get(key)"))


### PR DESCRIPTION
I noticed in my work on #1348 that the `Locale` compose context threw errors because the language files moved.

Opening this PR as it should be independent of that PR

Original change happened in #1334 

I took a look and I've already written tests for this class, which will be introduced within the `welcome-screen` branch