### PR TITLE
Reload legacy Preferences after saving

### DIFF
--- a/app/src/processing/app/Preferences.kt
+++ b/app/src/processing/app/Preferences.kt
@@ -131,6 +131,9 @@ fun PreferencesProvider(content: @Composable () -> Unit) {
                             .joinToString("\n") { (key, value) -> "$key=$value" }
                             .toByteArray()
                     )
+                    
+                    // Reload legacy Preferences
+                    Preferences.init()
                 }
             }
     }


### PR DESCRIPTION
Fixes this bug reported on the discord:


https://github.com/user-attachments/assets/ae8eb77d-aef9-4015-904f-fbcc7215d223


Calls Preferences.init() after saving preferences to ensure legacy Preferences are reloaded and kept in sync with the latest changes. Otherwise the new preferences state from compose would be overridden from the legacy system