### PR TITLE
Replace System.err with Messages.showWarning

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1213,7 +1213,7 @@ public class Base {
       File destFolder = File.createTempFile("zip", "tmp", untitledFolder);
       if (!destFolder.delete() || !destFolder.mkdirs()) {
         // Hard to imagine why this would happen, but...
-        System.err.println("Could not create temporary folder " + destFolder);
+          Messages.showWarning("Could not create temporary folder " + destFolder);
         return null;
       }
       Util.unzip(zipFile, destFolder);
@@ -1225,11 +1225,11 @@ public class Base {
             return handleOpenUntitled(sketchFile.getAbsolutePath());
           }
         } else {
-          System.err.println("Expecting one folder inside " +
+            Messages.showWarning("Expecting one folder inside " +
             SKETCH_BUNDLE_EXT + " file, found " + fileList.length + ".");
         }
       } else {
-        System.err.println("Could not read " + destFolder);
+          Messages.showWarning("Could not read " + destFolder);
       }
     } catch (IOException e) {
       e.printStackTrace();


### PR DESCRIPTION
Updated error reporting in Base.java to use Messages.showWarning instead of System.err for user-facing warnings when handling temporary folder creation and reading.


Context: https://discord.com/channels/1076634729618624534/1229526727320146042/1449003335293341817