### PR TITLE
Load supported locales from locales.txt file

### DIFF
--- a/app/src/main/resources/languages/locales.txt
+++ b/app/src/main/resources/languages/locales.txt
@@ -1,0 +1,17 @@
+ar
+ca
+de
+el
+en
+es
+fr
+it
+ja
+ko
+nl
+pt
+ru
+tr
+uk
+zh-CN
+zh-TW

--- a/app/src/processing/app/Language.java
+++ b/app/src/processing/app/Language.java
@@ -22,7 +22,6 @@
 package processing.app;
 
 import processing.core.PApplet;
-import processing.data.StringList;
 
 import java.io.File;
 import java.io.IOException;
@@ -114,19 +113,13 @@ public class Language {
 
 
   static private String[] listSupported() {
-    StringList supported = new StringList();
-      var locales = Locale.getAvailableLocales();
       var loader = Language.class.getClassLoader();
-      for (var locale : locales) {
-          var language = locale.toLanguageTag();
-          var baseFilename = "languages/PDE_" + language + ".properties";
-          var file = loader.getResource(baseFilename);
-          if (file == null) {
-              continue;
-          }
-          supported.append(language);
+      try (var localeFile = loader.getResourceAsStream("languages/locales.txt")) {
+          return PApplet.loadStrings(localeFile);
+      } catch (IOException e) {
+          e.printStackTrace();
       }
-    return supported.toArray();
+      return new String[]{"en"};
   }
 
 


### PR DESCRIPTION
Refactors Language.listSupported() to read supported language codes from a new locales.txt resource file instead of scanning available locales.

Fixes a bug where the language files were not loaded correctly.