### PR TITLE
Fix tabbing issue with textfields

### DIFF
--- a/app/src/processing/app/ui/preferences/General.kt
+++ b/app/src/processing/app/ui/preferences/General.kt
@@ -46,6 +46,7 @@ class General {
                             modifier = Modifier.fillMaxWidth(),
                             label = { Text(locale["preferences.sketchbook_location"]) },
                             value = preference ?: "",
+                            singleLine = true,
                             onValueChange = {
                                 updatePreference(it)
                             },

--- a/app/src/processing/app/ui/preferences/Other.kt
+++ b/app/src/processing/app/ui/preferences/Other.kt
@@ -74,6 +74,7 @@ class Other {
                                         OutlinedTextField(
                                             modifier = Modifier.widthIn(max = 300.dp),
                                             value = preference ?: "",
+                                            singleLine = true,
                                             onValueChange = {
                                                 updatePreference(it)
                                             }

--- a/app/src/processing/app/ui/preferences/Sketches.kt
+++ b/app/src/processing/app/ui/preferences/Sketches.kt
@@ -118,6 +118,7 @@ class Sketches {
                             enabled = LocalPreferences.current["run.options.memory"]?.toBoolean() ?: false,
                             modifier = Modifier.widthIn(max = 300.dp),
                             value = preference ?: "",
+                            singleLine = true,
                             trailingIcon = { Text("MB") },
                             onValueChange = {
                                 setPreference(it)


### PR DESCRIPTION
Context: 
https://discourse.processing.org/t/processing-4-5-beta-is-out/47637/6

Changes textfields to single lines so they don't capture the tab-indexing