### PR TITLE
fix: update cli help link to relevant wiki

### DIFF
--- a/java/src/processing/mode/java/Commander.java
+++ b/java/src/processing/mode/java/Commander.java
@@ -383,7 +383,7 @@ public class Commander implements RunnerListener {
     out.println("be passed through to the sketch itself, and therefore available to the");
     out.println("sketch via the 'args' field. To pass options understood by PApplet.main(),");
     out.println("write a custom main() method so that the preprocessor does not add one.");
-    out.println("https://github.com/processing/processing/wiki/Command-Line");
+    out.println("https://github.com/processing/processing4/wiki/Command-Line");
     out.println();
   }
 


### PR DESCRIPTION
Just changes the outdated link.