### PR TITLE
Refactor Other preferences registration logic

### DIFF
--- a/app/src/processing/app/ui/PDEPreferences.kt
+++ b/app/src/processing/app/ui/PDEPreferences.kt
@@ -99,7 +99,7 @@ class PDEPreferences {
             Interface.register()
             Coding.register()
             Sketches.register()
-            Other.register(panes)
+            Other.register()
         }
 
         /**
@@ -110,6 +110,8 @@ class PDEPreferences {
         fun preferences() {
             val locale = LocalLocale.current
             var preferencesQuery by remember { mutableStateOf("") }
+
+            Other.handleOtherPreferences(panes)
 
             /**
              * Filter panes based on the search query.

--- a/app/src/processing/app/ui/preferences/Other.kt
+++ b/app/src/processing/app/ui/preferences/Other.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -27,7 +28,7 @@ class Other {
             after = sketches
         )
 
-        fun register(panes: PDEPreferencePanes) {
+        fun register() {
             PDEPreferences.register(
                 PDEPreference(
                     key = "preferences.show_other",
@@ -41,57 +42,61 @@ class Other {
                                 setPreference(it.toString())
                             }
                         )
-                        if (!showOther) {
-                            return@PDEPreference
-                        }
-                        val prefs = LocalPreferences.current
-                        val locale = LocalLocale.current
-                        DisposableEffect(Unit) {
-                            // add all the other options to the same group as the current one
-                            val group =
-                                panes[other]?.find { group -> group.any { preference -> preference.key == "preferences.show_other" } } as? MutableList<PDEPreference>
-
-                            val existing = panes.values.flatten().flatten().map { preference -> preference.key }
-                            val keys = prefs.keys.mapNotNull { it as? String }.filter { it !in existing }.sorted()
-
-                            for (prefKey in keys) {
-                                val descriptionKey = "preferences.$prefKey"
-                                val preference = PDEPreference(
-                                    key = prefKey,
-                                    descriptionKey = if (locale.containsKey(descriptionKey)) descriptionKey else prefKey,
-                                    pane = other,
-                                    control = { preference, updatePreference ->
-                                        if (preference?.toBooleanStrictOrNull() != null) {
-                                            Switch(
-                                                checked = preference.toBoolean(),
-                                                onCheckedChange = {
-                                                    updatePreference(it.toString())
-                                                }
-                                            )
-                                            return@PDEPreference
-                                        }
-
-                                        OutlinedTextField(
-                                            modifier = Modifier.widthIn(max = 300.dp),
-                                            value = preference ?: "",
-                                            singleLine = true,
-                                            onValueChange = {
-                                                updatePreference(it)
-                                            }
-                                        )
-                                    }
-                                )
-                                group?.add(preference)
-                            }
-                            onDispose {
-                                group?.apply {
-                                    removeIf { it.key != "preferences.show_other" }
-                                }
-                            }
-                        }
                     }
                 )
             )
+        }
+
+        @Composable
+        fun handleOtherPreferences(panes: PDEPreferencePanes) {
+            // This function can be used to handle any specific logic related to other preferences if needed
+            val prefs = LocalPreferences.current
+            val locale = LocalLocale.current
+            if (prefs["preferences.show_other"]?.toBoolean() != true) {
+                return
+            }
+            DisposableEffect(panes) {
+                // add all the other options to the same group as the current one
+                val group =
+                    panes[other]?.find { group -> group.any { preference -> preference.key == "preferences.show_other" } } as? MutableList<PDEPreference>
+
+                val existing = panes.values.flatten().flatten().map { preference -> preference.key }
+                val keys = prefs.keys.mapNotNull { it as? String }.filter { it !in existing }.sorted()
+
+                for (prefKey in keys) {
+                    val descriptionKey = "preferences.$prefKey"
+                    val preference = PDEPreference(
+                        key = prefKey,
+                        descriptionKey = if (locale.containsKey(descriptionKey)) descriptionKey else prefKey,
+                        pane = other,
+                        control = { preference, updatePreference ->
+                            if (preference?.toBooleanStrictOrNull() != null) {
+                                Switch(
+                                    checked = preference.toBoolean(),
+                                    onCheckedChange = {
+                                        updatePreference(it.toString())
+                                    }
+                                )
+                                return@PDEPreference
+                            }
+
+                            OutlinedTextField(
+                                modifier = Modifier.widthIn(max = 300.dp),
+                                value = preference ?: "",
+                                onValueChange = {
+                                    updatePreference(it)
+                                }
+                            )
+                        }
+                    )
+                    group?.add(preference)
+                }
+                onDispose {
+                    group?.apply {
+                        removeIf { it.key != "preferences.show_other" }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Made sure the logic for displaying experimental settings runs regardless of the visibility of the toggle

Closes #1368 