### PR TITLE
Fixed an issue where the Preferences file stream was left open

### DIFF
--- a/app/src/processing/app/Preferences.kt
+++ b/app/src/processing/app/Preferences.kt
@@ -103,15 +103,17 @@ fun PreferencesProvider(content: @Composable () -> Unit) {
         ReactiveProperties().apply {
             val defaultsStream = ClassLoader.getSystemResourceAsStream(DEFAULTS_FILE_NAME)
                 ?: InputStream.nullInputStream()
-            load(
-                defaultsStream
-                    .reader(Charsets.UTF_8)
-            )
-            load(
-                preferencesFile
-                    .inputStream()
-                    .reader(Charsets.UTF_8)
-            )
+            defaultsStream
+                .reader(Charsets.UTF_8)
+                .use { reader ->
+                    load(reader)
+                }
+            preferencesFile
+                .inputStream()
+                .reader(Charsets.UTF_8)
+                .use { reader ->
+                    load(reader)
+                }
         }
     }
 
@@ -135,6 +137,7 @@ fun PreferencesProvider(content: @Composable () -> Unit) {
                     
                     // Reload legacy Preferences
                     Preferences.init()
+                    output.close()
                 }
             }
     }


### PR DESCRIPTION
Found and resolved an issue where the Preference file was left open causing other parts of Processing to refuse to modify file any further

Closes #1374 