### PR TITLE
Added `rebuildToolList()` to fix nullpointer in contributions check

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -485,6 +485,7 @@ public class Base {
     buildCoreModes();
     rebuildContribModes();
     rebuildContribExamples();
+      rebuildToolList();
 
     // Needs to happen after the sketchbook folder has been located.
     // Also relies on the modes to be loaded, so it knows what can be

--- a/app/src/processing/app/contrib/ContributionListing.java
+++ b/app/src/processing/app/contrib/ContributionListing.java
@@ -21,14 +21,6 @@
 */
 package processing.app.contrib;
 
-import java.awt.EventQueue;
-import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.net.*;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
-
 import processing.app.Base;
 import processing.app.Messages;
 import processing.app.UpdateCheck;
@@ -36,6 +28,16 @@ import processing.app.Util;
 import processing.core.PApplet;
 import processing.data.StringDict;
 import processing.data.StringList;
+
+import java.awt.*;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 
 public class ContributionListing {
@@ -275,6 +277,8 @@ public class ContributionListing {
       } catch (MalformedURLException e) {
         progress.setException(e);
         progress.finished();
+      } catch (Exception e) {
+          Messages.log(e.getMessage());
       } finally {
         downloadingLock.unlock();
       }


### PR DESCRIPTION
I just discovered that in 4.5.0 the contributions update didn't actually work, as the order of the logic changed in https://github.com/processing/processing4/pull/1299 and the tools list did not get build before it was being read.
In general I think we should really start rebuilding the startup logic of the PDE, as currently it is really hard to understand the interdependencies between different sections, also these sections do not work standalone at all. 