### PR TITLE
Use `starting` to fully remove the window

### DIFF
--- a/app/src/processing/app/ui/Start.kt
+++ b/app/src/processing/app/ui/Start.kt
@@ -78,7 +78,7 @@ class Start {
                                 .addAWTEventListener({ event ->
                                     if (event.id != WindowEvent.WINDOW_OPENED) return@addAWTEventListener
 
-                                    visible = false
+                                    starting = false
                                 }, AWTEvent.WINDOW_EVENT_MASK);
                         }
                         Image(


### PR DESCRIPTION
Previously the window would only hide it's contents because the wrong variable was used