### PR TITLE
Make `CapturePreferences` only keep track of changes

### DIFF
--- a/app/src/processing/app/ui/PDEPreferences.kt
+++ b/app/src/processing/app/ui/PDEPreferences.kt
@@ -441,7 +441,7 @@ private val LocalModifiablePreferences =
     compositionLocalOf { ModifiablePreference(null, false, { }, {}) }
 
 /**
- * Composable function that provides a modifiable copy of the current preferences.
+ * Composable function that captures an initial copy of the current preferences.
  * This allows for temporary changes to preferences that can be reset or applied later.
  *
  * @param content The composable content that will have access to the modifiable preferences.
@@ -498,13 +498,13 @@ private fun CapturePreferences(content: @Composable () -> Unit) {
     }
 
     val apply = {
-        modified.entries.forEach { (key, value) ->
-            prefs.setProperty(key as String, (value ?: "") as String)
+        prefs.entries.forEach { (key, value) ->
+            modified.setProperty(key as String, (value ?: "") as String)
         }
     }
     val reset = {
         modified.entries.forEach { (key, value) ->
-            modified.setProperty(key as String, prefs[key] ?: "")
+            prefs.setProperty(key as String, modified[key] ?: "")
         }
     }
     val state = ModifiablePreference(
@@ -515,7 +515,6 @@ private fun CapturePreferences(content: @Composable () -> Unit) {
     )
 
     CompositionLocalProvider(
-        LocalPreferences provides modified,
         LocalModifiablePreferences provides state
     ) {
         content()


### PR DESCRIPTION
Before `CapturePreferences` would override `LocalPreferences` and halt any changes upstream until `apply` was called, now it will let those changes slip through so we get immediate feedback on changes made in the preferences screen.