### PR TITLE
Create `PreferencesEvents` to glue into base and other deps

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -198,6 +198,8 @@ public class Base {
     // run static initialization that grabs all the prefs
     Preferences.init();
 
+      PreferencesEvents.onUpdated(Preferences::init);
+
     // boolean flag indicating whether to create new server instance or not
     boolean createNewInstance = DEBUG || !SingleInstance.alreadyRunning(args);
 

--- a/app/src/processing/app/Preferences.kt
+++ b/app/src/processing/app/Preferences.kt
@@ -1,12 +1,9 @@
 package processing.app
 
 import androidx.compose.runtime.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.dropWhile
-import kotlinx.coroutines.launch
 import processing.utils.Settings
 import java.io.File
 import java.io.InputStream
@@ -134,10 +131,9 @@ fun PreferencesProvider(content: @Composable () -> Unit) {
                             .joinToString("\n") { (key, value) -> "$key=$value" }
                             .toByteArray()
                     )
-                    
-                    // Reload legacy Preferences
-                    Preferences.init()
                     output.close()
+
+                    PreferencesEvents.updated()
                 }
             }
     }
@@ -205,4 +201,19 @@ fun watchFile(file: File): Any? {
         }
     }
     return event
+}
+
+class PreferencesEvents {
+    companion object {
+        val updatedListeners = mutableListOf<Runnable>()
+
+        @JvmStatic
+        fun onUpdated(callback: Runnable) {
+            updatedListeners.add(callback)
+        }
+
+        fun updated() {
+            updatedListeners.forEach { it.run() }
+        }
+    }
 }

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -371,6 +371,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
       });
     }
 
+      PreferencesEvents.onUpdated(this::updateTheme);
   }
 
 


### PR DESCRIPTION
To avoid creating dependencies within Preferences.kt, create an event structure that will listen to changes triggered by saving the Preferences.