### PR TITLE
Upgrade to jogl 2.6 on maven

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://jogamp.org/deployment/maven") }
 }
 
 sourceSets{

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.2.20"
 compose-plugin = "1.9.1"
-jogl = "2.5.0"
+jogl = "2.6.0"
 antlr = "4.13.2"
 jupiter = "5.12.0"
 markdown = "0.37.0"


### PR DESCRIPTION
Context

https://discord.com/channels/1076634729618624534/1229526727320146042/1466062032137883811

We would love to update to the 2.6 version of JOGL on Maven Central, this would remove the requirement for Processing and downstream users of `core` to define the Jogamp repo, a problem I have run into many many times. 

Closes #942 

@catilac @SableRaf This could be released as a 4.5.2 on GitHub and Maven only

When testing, make sure you run a clean build