### PR TITLE
Read preferences txt, if fails, read defaults, else really break

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -336,7 +336,15 @@ public class Preferences {
 
 
   static public int getInteger(String attribute /*, int defaultValue*/) {
-    return Integer.parseInt(get(attribute));
+    try {
+      return Integer.parseInt(get(attribute));
+    } catch (NumberFormatException err) {
+      try {
+        return Integer.parseInt(getDefault(attribute));
+      } catch (NumberFormatException err2) {
+        throw new IllegalArgumentException("Cannot parse: " + attribute);
+      }
+    }
   }
 
 


### PR DESCRIPTION
This is a bandaid fix for the tab-spacing Advanced error that was reported.
I'm carving out a set of issues for a larger fix. 

@SableRaf can you please give this a little test?

partial fix of https://github.com/processing/processing4/issues/1388

