### PR TITLE
fix syntax error in all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1688,6 +1688,7 @@
         "doc"
       ]
     },
+    {
       "login": "avinxshKD",
       "name": "Avinash Kumar Deepak",
       "avatar_url": "https://avatars.githubusercontent.com/u/152387616?v=4",


### PR DESCRIPTION
there was a merge conflict i fixed by hand, and i introduced a typo. this fixes it. 
i confirmed using `jq` 

`cat .all-contributorsrc | jq`