### PR TITLE
Add PR artifact uploads and comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,15 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew test
+
+      - name: Add comment with binaries
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          append: true
+          header: artifacts
+          message: |
+            Tests completed successfully. Build artifacts will be available after the build job.
   build:
     name: (${{ matrix.os_prefix }}/${{ matrix.arch }}) Create Processing Build
     runs-on: ${{ matrix.os }}
@@ -74,6 +83,7 @@ jobs:
 
       - name: Add artifact for PR
         if: ${{ github.event_name == 'pull_request' }}
+        id: upload-artifact
         uses: actions/upload-artifact@v4
         with:
           name: processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}
@@ -85,9 +95,9 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           append: true
-          header: '## Build Artifacts'
+          header: artifacts
           message: |
-            ### (${{ matrix.os_prefix }}/${{ matrix.arch }}) Build Artifacts
-            - [Download processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}](${{ steps.upload-artifact.outputs.download_url }})
+            ### (${{ matrix.os_prefix }}/${{ matrix.arch }})
+            - [Download processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}](${{ steps.upload-artifact.outputs.artifact-url }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,11 @@ jobs:
           append: true
           header: artifacts
           message: |
-            Tests completed successfully. Build artifacts will be available after the build job.
+            Tests completed successfully.
+            
+            ### Build Artifacts
+            |  Platform | Download |
+            |:-:|------------------------|
   build:
     name: (${{ matrix.os_prefix }}/${{ matrix.arch }}) Create Processing Build
     runs-on: ${{ matrix.os }}
@@ -97,7 +101,6 @@ jobs:
           append: true
           header: artifacts
           message: |
-            ### (${{ matrix.os_prefix }}/${{ matrix.arch }})
-            - [Download processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}](${{ steps.upload-artifact.outputs.artifact-url }})
+            |(${{ matrix.os_prefix }}/${{ matrix.arch }})|[Download processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}](${{ steps.upload-artifact.outputs.artifact-url }})|
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,13 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          append: true
           header: artifacts
           message: |
-            Tests completed successfully.
+            Tests completed successfully. Build artifacts for this pull request will appear below once ready.
             
             ### Build Artifacts
-            |  Platform | Download |
-            |:-:|------------------------|
+            | Platform | Link |
+            |:--|------------------------|
   build:
     name: (${{ matrix.os_prefix }}/${{ matrix.arch }}) Create Processing Build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,14 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: artifacts
+          GITHUB_TOKEN: ${{ secrets.PR_PAT }}
           message: |
             Tests completed successfully. Build artifacts for this pull request will appear below once ready.
             
             ### Build Artifacts
             | Platform | Link |
             |:--|------------------------|
+
   build:
     name: (${{ matrix.os_prefix }}/${{ matrix.arch }}) Create Processing Build
     runs-on: ${{ matrix.os }}
@@ -99,7 +101,7 @@ jobs:
         with:
           append: true
           header: artifacts
+          GITHUB_TOKEN: ${{ secrets.PR_PAT }}
           message: |
             |(${{ matrix.os_prefix }}/${{ matrix.arch }})|[Download processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}](${{ steps.upload-artifact.outputs.artifact-url }})|
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
     name: (${{ matrix.os_prefix }}/${{ matrix.arch }}) Create Processing Build
     runs-on: ${{ matrix.os }}
     needs: test
+    permissions:
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +66,28 @@ jobs:
 
       - name: Add artifact
         uses: actions/upload-artifact@v4
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           name: processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-br_${{ github.ref_name }}
           retention-days: 1
           path: app/build/compose/binaries/main/${{ matrix.binary }}
+
+      - name: Add artifact for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}
+          retention-days: 5
+          path: app/build/compose/binaries/main/${{ matrix.binary }}
+
+      - name: Add comment with binaries
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          append: true
+          header: '## Build Artifacts'
+          message: |
+            ### (${{ matrix.os_prefix }}/${{ matrix.arch }}) Build Artifacts
+            - [Download processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-pr_${{ github.event.pull_request.number }}](${{ steps.upload-artifact.outputs.download_url }})
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the build workflow to handle pull request runs: make the main artifact upload conditional (skip for pull_request), add a separate upload step for PR artifacts with longer retention, and post a sticky PR comment containing a download link. Also adjust workflow permissions to allow pull-request write access and include updated artifact paths.

See bot output here https://github.com/Stefterv/processing4/pull/11#issuecomment-3847385548