### PR TITLE
Publish Processing Gradle plugins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,19 @@ jobs:
       - name: Setup Processing
         uses: ./.github/actions/setup
 
-      - name: Build with Gradle
+      - name: Publish plugins to Gradle Plugin Portal
+        run: ./gradlew publishPlugins
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
+
+          ORG_GRADLE_PROJECT_version: ${{ needs.version.outputs.version }}
+          ORG_GRADLE_PROJECT_group: ${{ vars.GRADLE_GROUP }}
+                
+      - name: Publish internal plugins to Gradle Plugin Portal
         run: ./gradlew -c gradle/plugins/settings.gradle.kts publishPlugins
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,31 @@ jobs:
 
         ORG_GRADLE_PROJECT_version: ${{ needs.version.outputs.version }}
         ORG_GRADLE_PROJECT_group: ${{ vars.GRADLE_GROUP }}
+
+  publish-gradle:
+    name: Publish Processing Plugins to Gradle Plugin Portal
+    runs-on: ubuntu-latest
+    needs: version
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Processing
+        uses: ./.github/actions/setup
+
+      - name: Build with Gradle
+        run: ./gradlew -c gradle/plugins/settings.gradle.kts publishPlugins
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
+
+          ORG_GRADLE_PROJECT_version: ${{ needs.version.outputs.version }}
+          ORG_GRADLE_PROJECT_group: ${{ vars.GRADLE_GROUP }}
+          ORG_GRADLE_PROJECT_publishingGroup: ${{ vars.GRADLE_GROUP }}
+
   release-windows:
     name: (windows/${{ matrix.arch }}) Create Processing Release
     runs-on: ${{ matrix.os }}

--- a/gradle/plugins/library/build.gradle.kts
+++ b/gradle/plugins/library/build.gradle.kts
@@ -1,12 +1,17 @@
 plugins {
-    `java-gradle-plugin`
+    id("com.gradle.plugin-publish") version "2.0.0"
     kotlin("jvm") version "2.2.20"
 }
 
 gradlePlugin {
+    website = "https://processing.org/"
+    vcsUrl = "https://github.com/processing/processing4"
     plugins {
         create("processing.library") {
-            id = "org.processing.library"
+            id = project.properties.getOrElse("publishingGroup", { "org.processing" }).toString() + ".library"
+            displayName = "Processing Library Plugin"
+            description = "Gradle plugin for building Processing libraries"
+            tags = listOf("processing", "library", "dsl")
             implementationClass = "ProcessingLibraryPlugin"
         }
     }

--- a/java/gradle/build.gradle.kts
+++ b/java/gradle/build.gradle.kts
@@ -44,3 +44,7 @@ publishing{
         }
     }
 }
+
+tasks.withType<Test>().configureEach {
+    systemProperty("project.group", group ?: "org.processing")
+}

--- a/java/gradle/build.gradle.kts
+++ b/java/gradle/build.gradle.kts
@@ -21,15 +21,20 @@ dependencies{
     testImplementation(libs.junit)
 }
 
-// TODO: CI/CD for publishing the plugin to the Gradle Plugin Portal
 gradlePlugin{
+    website = "https://processing.org/"
+    vcsUrl = "https://github.com/processing/processing4"
     plugins{
         create("processing.java"){
-            id = "org.processing.java"
+            id = "$group.java"
+            displayName = "Processing Plugin"
+            description = "Gradle plugin for building Processing sketches"
+            tags = listOf("processing", "sketch", "dsl")
             implementationClass = "org.processing.java.gradle.ProcessingPlugin"
         }
     }
 }
+
 publishing{
     repositories{
         mavenLocal()

--- a/java/gradle/build.gradle.kts
+++ b/java/gradle/build.gradle.kts
@@ -44,7 +44,8 @@ publishing{
         }
     }
 }
-
+// Grab the group before running tests, since the group is used in the test configuration and may be modified by the publishing configuration
+val testGroup = group.toString()
 tasks.withType<Test>().configureEach {
-    systemProperty("project.group", group ?: "org.processing")
+    systemProperty("project.group", testGroup)
 }

--- a/java/gradle/src/test/kotlin/ProcessingPluginTest.kt
+++ b/java/gradle/src/test/kotlin/ProcessingPluginTest.kt
@@ -20,7 +20,7 @@ class ProcessingPluginTest{
         val sketchFolder = directory.newFolder("sketch")
         directory.newFile("sketch/build.gradle.kts").writeText("""
             plugins {
-                id("org.processing.java")
+                id("${System.getProperty("project.group")}.java")
             }
         """.trimIndent())
         directory.newFile("sketch/settings.gradle.kts")


### PR DESCRIPTION
Add a publish-gradle job to the release workflow to publish Processing libraries to the Gradle Plugin Portal.

This way future processing libraries can be created by adding

    plugins{
        id("org.processing.library") version "4.5.3"
    }

    processing {
        library {
            version = 1
            prettyVersion = "1.0.0"
    
            authors = mapOf(
                "The Processing Foundation" to "https://processing.org"
            )
            url = "https://processing.org/"
            categories = listOf("file", "exporter", "dxf")
    
            sentence = "DXF export library for Processing"
            paragraph =
                "This library allows you to export your Processing drawings as DXF files, which can be opened in CAD applications."
    
        }
    }

To any standard Java/Kotlin gradle project, this will then handle packaging the library. We can add more functionality to it over time and the only thing library authors will need to do is update the plugin version.

TODO:
- [x] Create Gradle Portal Account (account created with the processing-bot)
- [x] Set repository secrets (GRADLE_PUBLISH_KEY, GRADLE_PUBLISH_SECRET)

After merge:

- [ ] Update the processing gradle library template

Related:
https://github.com/processing/processing4/pull/1347
https://github.com/processing/processing4/pull/1233