### PR TITLE
Publish `org.processing.core.pdf` to maven Central

### DIFF
--- a/java/libraries/pdf/build.gradle.kts
+++ b/java/libraries/pdf/build.gradle.kts
@@ -1,5 +1,8 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins{
     java
+    alias(libs.plugins.mavenPublish)
 }
 
 sourceSets {
@@ -36,5 +39,48 @@ tasks.register<Copy>("createLibrary"){
     from(tasks.jar) {
         into("library")
         rename { "pdf.jar" }
+    }
+}
+
+publishing{
+    repositories{
+        maven {
+            name = "App"
+            url = uri(project(":app").layout.buildDirectory.dir("resources-bundled/common/repository").get().asFile.absolutePath)
+        }
+    }
+}
+
+mavenPublishing{
+    coordinates("$group.core", name, version.toString())
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+
+    signAllPublications()
+
+    pom{
+        name.set("Processing PDF")
+        description.set("Processing PDF")
+        url.set("https://processing.org")
+        licenses {
+            license {
+                name.set("LGPL")
+                url.set("https://www.gnu.org/licenses/lgpl-2.1.html")
+            }
+        }
+        developers {
+            developer {
+                id.set("steftervelde")
+                name.set("Stef Tervelde")
+            }
+            developer {
+                id.set("benfry")
+                name.set("Ben Fry")
+            }
+        }
+        scm{
+            url.set("https://github.com/processing/processing4")
+            connection.set("scm:git:git://github.com/processing/processing4.git")
+            developerConnection.set("scm:git:ssh://git@github.com/processing/processing4.git")
+        }
     }
 }


### PR DESCRIPTION
Adds Maven Central publishing configuration to the PDF library.

- Added maven-publish plugin
- Added publishing block for local app repository
- Added mavenPublishing block with POM metadata
- Follows same pattern as preprocessor module

Part of #1403