### PR TITLE
Remove Welcome Survey link, and unused function

### DIFF
--- a/app/src/processing/app/ui/PDEWelcome.kt
+++ b/app/src/processing/app/ui/PDEWelcome.kt
@@ -571,7 +571,7 @@ fun showWelcomeScreen(base: Base? = null) {
         unique = WelcomeScreen::class,
         fullWindowContent = true
     ) {
-        PDEWelcomeWithSurvey(base)
+        PDEWelcome(base)
     }
 }
 
@@ -620,12 +620,12 @@ fun main(){
     application {
         PDEComposeWindow(titleKey = titleKey, size = size, fullWindowContent = true) {
             PDETheme(darkTheme = true) {
-                PDEWelcomeWithSurvey()
+                PDEWelcome()
             }
         }
         PDEComposeWindow(titleKey = titleKey, size = size, fullWindowContent = true) {
             PDETheme(darkTheme = false) {
-                PDEWelcomeWithSurvey()
+                PDEWelcome()
             }
         }
     }

--- a/app/src/processing/app/ui/WelcomeSurvey.kt
+++ b/app/src/processing/app/ui/WelcomeSurvey.kt
@@ -23,17 +23,6 @@ import processing.app.ui.theme.LocalLocale
 import processing.app.ui.theme.PDETheme
 import javax.swing.JComponent
 
-
-fun addSurveyToWelcomeScreen(): JComponent {
-    return ComposePanel().apply {
-        setContent {
-            PDETheme {
-                SurveyInvitation()
-            }
-        }
-    }
-}
-
 @Composable
 fun SurveyInvitation() {
     val locale = LocalLocale.current


### PR DESCRIPTION
Fixes #1404 

I've preserved the component for adding a survey link, so we can always bring it back, or repurpose the toast in the future.

Let me know if it works, and I'll cut a release. 