### PR TITLE
use github.sha instead of ref_name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,6 @@ jobs:
       - name: Add artifact
         uses: actions/upload-artifact@v4
         with:
-          name: processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-br_${{ github.ref_name }}
+          name: processing-${{ matrix.os_prefix }}-${{ matrix.arch }}-br_${{ github.sha }}
           retention-days: 1
           path: app/build/compose/binaries/main/${{ matrix.binary }}


### PR DESCRIPTION
I want to fix the broken builds having to do with the '/' character. An artifact of using `github.ref_name` on branches that aren't merged in yet. `github.sha` will give us a unique identifier 