### PR TITLE
Publish Serial and IO libraries to Maven Central

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -68,7 +68,7 @@ tasks.register<Copy>("copyCore"){
     into(coreProject.layout.projectDirectory.dir("library"))
 }
 
-val legacyLibraries = arrayOf("io","net")
+val legacyLibraries = emptyArray<String>()
 legacyLibraries.forEach { library ->
     tasks.register<Copy>("library-$library-extraResources"){
         val build = project(":java:libraries:$library").tasks.named("build")
@@ -87,7 +87,7 @@ legacyLibraries.forEach { library ->
     }
 }
 
-val libraries = arrayOf("dxf", "pdf", "serial", "svg")
+val libraries = arrayOf("dxf", "io", "net", "pdf", "serial", "svg")
 
 libraries.forEach { library ->
     val name = "create-$library-library"

--- a/java/libraries/io/build.gradle.kts
+++ b/java/libraries/io/build.gradle.kts
@@ -1,1 +1,92 @@
-ant.importBuild("build.xml")
+import com.vanniktech.maven.publish.SonatypeHost
+
+plugins {
+    java
+    alias(libs.plugins.mavenPublish)
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs("src")
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(project(":core"))
+}
+
+tasks.register<Copy>("createLibrary") {
+    dependsOn("jar")
+    into(layout.buildDirectory.dir("library"))
+
+    from(layout.projectDirectory) {
+        include("library.properties")
+        include("examples/**")
+    }
+
+    from(configurations.runtimeClasspath) {
+        into("library")
+    }
+
+    from(tasks.jar) {
+        into("library")
+        rename { "io.jar" }
+    }
+
+    from(layout.projectDirectory.dir("library")) {
+        include("linux-arm64/**")
+        include("linux-armv6hf/**")
+        include("linux32/**")
+        include("linux64/**")
+        into("library")
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "App"
+            url = uri(project(":app").layout.buildDirectory.dir("resources-bundled/common/repository").get().asFile.absolutePath)
+        }
+    }
+}
+
+mavenPublishing {
+    coordinates("$group.core", name, version.toString())
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+
+    signAllPublications()
+
+    pom {
+        name.set("Processing IO")
+        description.set("Processing IO")
+        url.set("https://processing.org")
+        licenses {
+            license {
+                name.set("LGPL")
+                url.set("https://www.gnu.org/licenses/lgpl-2.1.html")
+            }
+        }
+        developers {
+            developer {
+                id.set("steftervelde")
+                name.set("Stef Tervelde")
+            }
+            developer {
+                id.set("benfry")
+                name.set("Ben Fry")
+            }
+        }
+        scm {
+            url.set("https://github.com/processing/processing4")
+            connection.set("scm:git:git://github.com/processing/processing4.git")
+            developerConnection.set("scm:git:ssh://git@github.com/processing/processing4.git")
+        }
+    }
+}

--- a/java/libraries/serial/build.gradle.kts
+++ b/java/libraries/serial/build.gradle.kts
@@ -1,5 +1,8 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     java
+    alias(libs.plugins.mavenPublish)
 }
 
 sourceSets {
@@ -23,15 +26,61 @@ dependencies {
 tasks.register<Copy>("createLibrary") {
     dependsOn("jar")
     into(layout.buildDirectory.dir("library"))
+
     from(layout.projectDirectory) {
         include("library.properties")
         include("examples/**")
     }
+
     from(configurations.runtimeClasspath) {
         into("library")
     }
+
     from(tasks.jar) {
         into("library")
         rename { "serial.jar" }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "App"
+            url = uri(project(":app").layout.buildDirectory.dir("resources-bundled/common/repository").get().asFile.absolutePath)
+        }
+    }
+}
+
+mavenPublishing {
+    coordinates("$group.core", name, version.toString())
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+
+    signAllPublications()
+
+    pom {
+        name.set("Processing Serial")
+        description.set("Processing Serial")
+        url.set("https://processing.org")
+        licenses {
+            license {
+                name.set("LGPL")
+                url.set("https://www.gnu.org/licenses/lgpl-2.1.html")
+            }
+        }
+        developers {
+            developer {
+                id.set("steftervelde")
+                name.set("Stef Tervelde")
+            }
+            developer {
+                id.set("benfry")
+                name.set("Ben Fry")
+            }
+        }
+        scm {
+            url.set("https://github.com/processing/processing4")
+            connection.set("scm:git:git://github.com/processing/processing4.git")
+            developerConnection.set("scm:git:ssh://git@github.com/processing/processing4.git")
+        }
     }
 }

--- a/java/libraries/serial/build.gradle.kts
+++ b/java/libraries/serial/build.gradle.kts
@@ -1,8 +1,5 @@
-import com.vanniktech.maven.publish.SonatypeHost
-
 plugins {
     java
-    alias(libs.plugins.mavenPublish)
 }
 
 sourceSets {
@@ -19,7 +16,8 @@ repositories {
 
 dependencies {
     compileOnly(project(":core"))
-    implementation("io.github.java-native:jssc:2.10.2")
+    // TODO: https://github.com/java-native/jssc
+    implementation(files("library/jssc.jar"))
 }
 
 tasks.register<Copy>("createLibrary") {
@@ -35,48 +33,5 @@ tasks.register<Copy>("createLibrary") {
     from(tasks.jar) {
         into("library")
         rename { "serial.jar" }
-    }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "App"
-            url = uri(project(":app").layout.buildDirectory.dir("resources-bundled/common/repository").get().asFile.absolutePath)
-        }
-    }
-}
-
-mavenPublishing {
-    coordinates("$group.core", name, version.toString())
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-
-    signAllPublications()
-
-    pom {
-        name.set("Processing Serial")
-        description.set("Processing Serial")
-        url.set("https://processing.org")
-        licenses {
-            license {
-                name.set("LGPL")
-                url.set("https://www.gnu.org/licenses/lgpl-2.1.html")
-            }
-        }
-        developers {
-            developer {
-                id.set("steftervelde")
-                name.set("Stef Tervelde")
-            }
-            developer {
-                id.set("benfry")
-                name.set("Ben Fry")
-            }
-        }
-        scm {
-            url.set("https://github.com/processing/processing4")
-            connection.set("scm:git:git://github.com/processing/processing4.git")
-            developerConnection.set("scm:git:ssh://git@github.com/processing/processing4.git")
-        }
     }
 }

--- a/java/libraries/serial/build.gradle.kts
+++ b/java/libraries/serial/build.gradle.kts
@@ -1,5 +1,8 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     java
+    alias(libs.plugins.mavenPublish)
 }
 
 sourceSets {
@@ -16,8 +19,7 @@ repositories {
 
 dependencies {
     compileOnly(project(":core"))
-    // TODO: https://github.com/java-native/jssc
-    implementation(files("library/jssc.jar"))
+    implementation("io.github.java-native:jssc:2.10.2")
 }
 
 tasks.register<Copy>("createLibrary") {
@@ -33,5 +35,48 @@ tasks.register<Copy>("createLibrary") {
     from(tasks.jar) {
         into("library")
         rename { "serial.jar" }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "App"
+            url = uri(project(":app").layout.buildDirectory.dir("resources-bundled/common/repository").get().asFile.absolutePath)
+        }
+    }
+}
+
+mavenPublishing {
+    coordinates("$group.core", name, version.toString())
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+
+    signAllPublications()
+
+    pom {
+        name.set("Processing Serial")
+        description.set("Processing Serial")
+        url.set("https://processing.org")
+        licenses {
+            license {
+                name.set("LGPL")
+                url.set("https://www.gnu.org/licenses/lgpl-2.1.html")
+            }
+        }
+        developers {
+            developer {
+                id.set("steftervelde")
+                name.set("Stef Tervelde")
+            }
+            developer {
+                id.set("benfry")
+                name.set("Ben Fry")
+            }
+        }
+        scm {
+            url.set("https://github.com/processing/processing4")
+            connection.set("scm:git:git://github.com/processing/processing4.git")
+            developerConnection.set("scm:git:ssh://git@github.com/processing/processing4.git")
+        }
     }
 }

--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -259,8 +259,12 @@ public class Serial implements SerialPortEventListener {
   }
 
 
+  /**
+   * @deprecated No longer supported
+   */
+  @Deprecated
   public static Map<String, String> getProperties(String portName) {
-    return SerialPortList.getPortProperties(portName);
+    return new java.util.HashMap<>();
   }
 
 

--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -259,12 +259,8 @@ public class Serial implements SerialPortEventListener {
   }
 
 
-  /**
-   * @deprecated No longer supported
-   */
-  @Deprecated
   public static Map<String, String> getProperties(String portName) {
-    return new java.util.HashMap<>();
+    return SerialPortList.getPortProperties(portName);
   }
 
 


### PR DESCRIPTION
Ported Serial and IO libraries from Ant to Gradle with Maven publishing, Serial now uses upstream jssc from Maven Central instead of the bundled fork. This completes the library migration work started in #1407 and #1411.

closes #1403