### PR TITLE
Processing Gradle Plugin - Version sync

### DIFF
--- a/java/gradle/build.gradle.kts
+++ b/java/gradle/build.gradle.kts
@@ -39,3 +39,15 @@ publishing{
         }
     }
 }
+
+tasks.register("writeVersion") {
+    // make the version available to the plugin at runtime by writing it to a properties file in the resources directory
+    doLast {
+        val file = layout.buildDirectory.file("resources/main/version.properties").get().asFile
+        file.parentFile.mkdirs()
+        file.writeText("version=${project.version}")
+    }
+}
+tasks.named("processResources") {
+    dependsOn("writeVersion")
+}

--- a/java/gradle/src/main/kotlin/ProcessingPlugin.kt
+++ b/java/gradle/src/main/kotlin/ProcessingPlugin.kt
@@ -20,7 +20,10 @@ class ProcessingPlugin @Inject constructor(private val objectFactory: ObjectFact
         val sketchName = project.layout.projectDirectory.asFile.name.replace(Regex("[^a-zA-Z0-9_]"), "_")
 
         val isProcessing = project.findProperty("processing.version") != null
-        val processingVersion = project.findProperty("processing.version") as String? ?: "4.3.4"
+        val processingVersion = project.findProperty("processing.version") as String?
+            ?: javaClass.classLoader.getResourceAsStream("version.properties")?.use { stream ->
+                java.util.Properties().apply { load(stream) }.getProperty("version")
+            } ?: "4.3.4"
         val processingGroup = project.findProperty("processing.group") as String? ?: "org.processing"
         val workingDir = project.findProperty("processing.workingDir") as String?
         val debugPort = project.findProperty("processing.debugPort") as String?


### PR DESCRIPTION
I was looking at the Gradle plugin code and realised I had missed something I had intended to implement. 

This PR adds a writeVersion Gradle task that writes project.version to build/resources/main/version.properties, so the plugin can access the plugin version at runtime. This way the version number of the plugin and the used version of processing.core will be the same.