### PR TITLE
Fix modal dialogs freezing all IDE windows (#1375)

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1155,6 +1155,7 @@ public class Base {
       // use the front-most window frame for placing file dialog
       FileDialog openDialog =
         new FileDialog(activeEditor, prompt, FileDialog.LOAD);
+        openDialog.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
 
       // Only show .pde files as eligible bachelors
       openDialog.setFilenameFilter((dir, name) -> {

--- a/app/src/processing/app/Messages.kt
+++ b/app/src/processing/app/Messages.kt
@@ -48,6 +48,19 @@ import javax.swing.UIManager
 
 class Messages {
     companion object {
+
+        /**
+         * Shows a modal dialog that only blocks its parent window,
+         * not all windows in the application.
+         */
+        private fun showModalDialog(message: Any, title: String, messageType: Int) {
+            val activeWindow = java.awt.KeyboardFocusManager
+                .getCurrentKeyboardFocusManager().activeWindow
+            val pane = JOptionPane(message, messageType)
+            val dialog = pane.createDialog(activeWindow, title)
+            dialog.modalityType = java.awt.Dialog.ModalityType.DOCUMENT_MODAL
+            dialog.isVisible = true
+        }
         /**
          * "No cookie for you" type messages. Nothing fatal or all that
          * much of a bummer, but something to notify the user about.
@@ -57,10 +70,7 @@ class Messages {
             if (Base.isCommandLine()) {
                 println("$title: $message")
             } else {
-                JOptionPane.showMessageDialog(
-                    Frame(), message, title,
-                    JOptionPane.INFORMATION_MESSAGE
-                )
+                showModalDialog(message, title, JOptionPane.INFORMATION_MESSAGE)
             }
         }
 
@@ -77,10 +87,7 @@ class Messages {
             if (Base.isCommandLine()) {
                 println("$title: $message")
             } else {
-                JOptionPane.showMessageDialog(
-                    Frame(), message, title,
-                    JOptionPane.WARNING_MESSAGE
-                )
+                showModalDialog(message, title, JOptionPane.WARNING_MESSAGE)
             }
             e?.printStackTrace()
         }
@@ -101,11 +108,7 @@ class Messages {
                 println("$title: $primary\n$secondary")
             } else {
                 EventQueue.invokeLater {
-                    JOptionPane.showMessageDialog(
-                        JFrame(),
-                        Toolkit.formatMessage(primary, secondary),
-                        title, JOptionPane.WARNING_MESSAGE
-                    )
+                    showModalDialog(Toolkit.formatMessage(primary, secondary), title, JOptionPane.WARNING_MESSAGE)
                 }
             }
             e?.printStackTrace()
@@ -122,10 +125,7 @@ class Messages {
             if (Base.isCommandLine()) {
                 System.err.println("$title: $message")
             } else {
-                JOptionPane.showMessageDialog(
-                    Frame(), message, title,
-                    JOptionPane.ERROR_MESSAGE
-                )
+                showModalDialog(message, title, JOptionPane.ERROR_MESSAGE)
             }
             e?.printStackTrace()
             System.exit(1)
@@ -151,9 +151,7 @@ class Messages {
                 val sw = StringWriter()
                 t!!.printStackTrace(PrintWriter(sw))
 
-                JOptionPane.showMessageDialog(
-                    Frame(),  // first <br/> clears to the next line
-                    // second <br/> is a shorter height blank space before the trace
+                showModalDialog(
                     Toolkit.formatMessage("$message<br/><tt><br/>$sw</tt>"),
                     title,
                     if (fatal) JOptionPane.ERROR_MESSAGE else JOptionPane.WARNING_MESSAGE

--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -34,6 +34,7 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.EventQueue;
 import java.awt.FileDialog;
+import java.awt.Dialog;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -866,6 +867,7 @@ public class Sketch {
     if (useNative) {
       // get new name for folder
       FileDialog fd = new FileDialog(editor, PROMPT, FileDialog.SAVE);
+      fd.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
       if (isReadOnly() || isUntitled()) {
         // default to the sketchbook folder
         fd.setDirectory(Preferences.getSketchbookPath());
@@ -1387,6 +1389,7 @@ public class Sketch {
     String prompt = Language.text("file");
     //FileDialog fd = new FileDialog(new Frame(), prompt, FileDialog.LOAD);
     FileDialog fd = new FileDialog(editor, prompt, FileDialog.LOAD);
+    fd.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
     fd.setVisible(true);
 
     String directory = fd.getDirectory();

--- a/core/src/processing/awt/ShimAWT.java
+++ b/core/src/processing/awt/ShimAWT.java
@@ -818,6 +818,7 @@ public class ShimAWT implements PConstants {
 
         if (PApplet.useNativeSelect) {
             FileDialog dialog = new FileDialog(parentFrame, prompt, mode);
+            dialog.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
             if (defaultSelection != null) {
                 dialog.setDirectory(defaultSelection.getParent());
                 dialog.setFile(defaultSelection.getName());
@@ -910,6 +911,7 @@ public class ShimAWT implements PConstants {
     if (PApplet.platform == PConstants.MACOS && PApplet.useNativeSelect) {
       FileDialog fileDialog =
         new FileDialog(parentFrame, prompt, FileDialog.LOAD);
+      fileDialog.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
       if (defaultSelection != null) {
         fileDialog.setDirectory(defaultSelection.getAbsolutePath());
       }


### PR DESCRIPTION
Problem
When a modal message appears (error, warning, "Save first", etc.), it freezes ALL Processing IDE windows. Users can't interact with any other window, and the modal can get lost behind other windows with no way to recover.

Root Cause
- `Messages.kt`: All popup dialogs used `Frame()` as their parent (an orphan frame with no connection to any editor window), causing `APPLICATION_MODAL`behaviour that blocks every window.
- `Base.java`, `Sketch.java`, `ShimAWT.java`: `FileDialog` instances did not set modality type, defaulting to `APPLICATION_MODAL`.

Fix
-Messages.kt: Created a `showModalDialog()` helper that finds the currently active window via `KeyboardFocusManager` and creates `DOCUMENT_MODAL` dialogs. Replaced all 5 `JOptionPane.showMessageDialog(Frame(), ...)` calls with this helper.
- **FileDialogs**: Set `DOCUMENT_MODAL` on all `FileDialog` instances in Base.java, Sketch.java, and ShimAWT.java.

Result
- Modal messages (errors, warnings, confirmations) now only block their parent window — other IDE windows remain fully interactive.
- File dialogs respect `DOCUMENT_MODAL` on Linux/Windows. Native macOS file dialogs ignore Java modality settings (Apple limitation), but all JOptionPane-based messages are fixed across all platforms.

Testing
- Opened 3+ editor windows
- Triggered error messages in each window
- Confirmed other windows remained responsive while popups were showing

Fixes #1375