### PR TITLE
fix portable settings.path not respected for prefs and language

### DIFF
--- a/app/src/processing/app/Preferences.kt
+++ b/app/src/processing/app/Preferences.kt
@@ -80,7 +80,7 @@ fun PreferencesProvider(content: @Composable () -> Unit) {
     val preferencesFileOverride: File? = System.getProperty("processing.app.preferences.file")?.let { File(it) }
     val preferencesDebounceOverride: Long? = System.getProperty("processing.app.preferences.debounce")?.toLongOrNull()
 
-    val settingsFolder = Settings.getFolder()
+    val settingsFolder = Base.getSettingsOverride() ?: Settings.getFolder()
     val preferencesFile = preferencesFileOverride ?: settingsFolder.resolve(PREFERENCES_FILE_NAME)
 
     if (!preferencesFile.exists()) {

--- a/app/src/processing/app/ui/theme/Locale.kt
+++ b/app/src/processing/app/ui/theme/Locale.kt
@@ -3,6 +3,7 @@ package processing.app.ui.theme
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
+import processing.app.Base
 import processing.app.Messages
 import processing.app.watchFile
 import processing.utils.Settings
@@ -90,7 +91,7 @@ var LastLocaleUpdate by mutableStateOf(0L)
  */
 @Composable
 fun LocaleProvider(content: @Composable () -> Unit) {
-    val settingsFolder = Settings.getFolder()
+    val settingsFolder = Base.getSettingsOverride() ?: Settings.getFolder()
     val languageFile = File(settingsFolder, "language.txt")
     watchFile(languageFile)
 


### PR DESCRIPTION
fixed #1435 
check Base.getSettingsOverride() before Settings.getFolder() in [Preferences.kt](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [Locale.kt](vscode-file://vscode-app/c:/Users/avina/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so portable settings.path works