### PR TITLE
Fix fullscreen_export.expected test values

### DIFF
--- a/java/test/resources/fullscreen_export.expected
+++ b/java/test/resources/fullscreen_export.expected
@@ -29,8 +29,8 @@ int x = 0;
 
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "--full-screen", "--bgcolor=null", "--hide-stop", "fullscreen_export" };
-        if (passedArgs != null) {
+    String[] appletArgs = new String[] { "--full-screen", "--bgcolor=#666666", "--stop-color=#cccccc", "fullscreen_export" };
+          if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {
             PApplet.main(appletArgs);


### PR DESCRIPTION
Fixes testMultiMultilineString failing test.

Updated fullscreen_export.expected to match 
current default values in defaults.txt:
- "--bgcolor=null" → "--bgcolor=#666666"
- "--hide-stop" → "--stop-color=#cccccc"

70 tests pass after this fix.