### PR TITLE
Add OVERLAY, HARD_LIGHT, SOFT_LIGHT blend modes to PImageTest

### DIFF
--- a/core/test/processing/core/PImageTest.java
+++ b/core/test/processing/core/PImageTest.java
@@ -231,11 +231,12 @@ public class PImageTest {
     img1.updatePixels();
     img2.updatePixels();
 
-    int[] modes = {
-        PConstants.BLEND, PConstants.ADD, PConstants.SUBTRACT, PConstants.LIGHTEST,
-        PConstants.DARKEST, PConstants.DIFFERENCE, PConstants.EXCLUSION,
-        PConstants.MULTIPLY, PConstants.SCREEN, PConstants.REPLACE
-    };
+      int[] modes = {
+              PConstants.BLEND, PConstants.ADD, PConstants.SUBTRACT, PConstants.LIGHTEST,
+              PConstants.DARKEST, PConstants.DIFFERENCE, PConstants.EXCLUSION,
+              PConstants.MULTIPLY, PConstants.SCREEN, PConstants.REPLACE,
+              PConstants.OVERLAY, PConstants.HARD_LIGHT, PConstants.SOFT_LIGHT
+      };
 
     for (int mode : modes) {
         PImage out = img1.copy();


### PR DESCRIPTION
## What this PR does
Extends testAllBlendModesExactMatchStaticHelper in PImageTest.java 
to include 3 missing blend modes:
- OVERLAY
- HARD_LIGHT
- SOFT_LIGHT

## Why
These blend modes exist in PConstants but were not being tested.
All 3 modes now verified against PImage.blendColor() static helper.