### PR TITLE
Fix JDK dirPermissions placement in gradle build files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -411,12 +411,12 @@ tasks.register<Copy>("includeJavaMode") {
     from(java.configurations.runtimeClasspath)
     into(composeResources("modes/java/mode"))
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    dirPermissions { unix("rwx------") }
 }
 tasks.register<Copy>("includeJdk") {
     from(Jvm.current().javaHome.absolutePath)
     destinationDir = composeResources("jdk").get().asFile
 
+    dirPermissions { unix("rwx------") }
     fileTree(destinationDir).files.forEach { file ->
         file.setWritable(true, false)
         file.setReadable(true, false)


### PR DESCRIPTION
This is required for building against read-only JDK installations (notably used when building with Nix). #1400 already attempted to integrate my nixpkgs patch for this purpose, but it accidentally placed the dirPermissions line under a different task.