### PR TITLE
Create gradle.properties in ProcessingPluginTest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
 
+        ORG_GRADLE_PROJECT_signMavenPackages: true
         ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
 
@@ -92,6 +93,7 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
 
+          ORG_GRADLE_PROJECT_signMavenPackages: true
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
 
@@ -104,6 +106,7 @@ jobs:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
 
+          ORG_GRADLE_PROJECT_signMavenPackages: true
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -38,7 +38,8 @@ dependencies {
 
 mavenPublishing{
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-    signAllPublications()
+    if (project.hasProperty("signMavenPackages"))
+        signAllPublications()
 
     pom{
         name.set("Processing Core")

--- a/java/gradle/build.gradle.kts
+++ b/java/gradle/build.gradle.kts
@@ -48,6 +48,7 @@ publishing{
 val testGroup = group.toString()
 tasks.withType<Test>().configureEach {
     systemProperty("project.group", testGroup)
+    dependsOn(project(":core").tasks.named("publishToMavenLocal"))
 }
 
 tasks.register("writeVersion") {

--- a/java/gradle/src/test/kotlin/ProcessingPluginTest.kt
+++ b/java/gradle/src/test/kotlin/ProcessingPluginTest.kt
@@ -24,6 +24,11 @@ class ProcessingPluginTest{
             }
         """.trimIndent())
         directory.newFile("sketch/settings.gradle.kts")
+        directory.newFile("sketch/gradle.properties").writeText(
+            """
+            processing.group=${System.getProperty("project.group").replace(".java", "")}
+            """.trimIndent()
+        )
         configure(sketchFolder)
 
         val buildResult = GradleRunner.create()
@@ -218,6 +223,7 @@ class ProcessingPluginTest{
             """.trimIndent())
             sketchFolder.resolve("gradle.properties").writeText(""")
                 processing.workingDir = ${sketchFolder.parentFile.absolutePath}
+                processing.group=${System.getProperty("project.group").replace(".java", "")}
             """.trimIndent())
         }
         val sketchClass = classLoader.loadClass("sketch")
@@ -250,9 +256,12 @@ class ProcessingPluginTest{
                     println("Hello World");
                 }
             """.trimIndent())
-            sketchFolder.resolve("gradle.properties").writeText(""")
+            sketchFolder.resolve("gradle.properties").writeText(
+                """
                 processing.sketchbook = ${libraryResult.libraryFolder.parentFile.parentFile.absolutePath}
-            """.trimIndent())
+                processing.group=${System.getProperty("project.group").replace(".java", "")}
+                """.trimIndent()
+            )
         }
 
         val sketchClass = classLoader.loadClass("sketch")

--- a/java/gradle/src/test/kotlin/ProcessingPluginTest.kt
+++ b/java/gradle/src/test/kotlin/ProcessingPluginTest.kt
@@ -23,7 +23,16 @@ class ProcessingPluginTest{
                 id("${System.getProperty("project.group")}.java")
             }
         """.trimIndent())
-        directory.newFile("sketch/settings.gradle.kts")
+        directory.newFile("sketch/settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                repositories {
+                    mavenLocal()
+                    gradlePluginPortal()
+                }
+            }
+        """.trimIndent()
+        )
         directory.newFile("sketch/gradle.properties").writeText(
             """
             processing.group=${System.getProperty("project.group").replace(".java", "")}

--- a/java/libraries/dxf/build.gradle.kts
+++ b/java/libraries/dxf/build.gradle.kts
@@ -32,7 +32,8 @@ sourceSets {
 
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-    signAllPublications()
+    if (project.hasProperty("signing.signMavenPackages"))
+        signAllPublications()
     coordinates("$group.core", name, version.toString())
 
     pom {

--- a/java/libraries/io/build.gradle.kts
+++ b/java/libraries/io/build.gradle.kts
@@ -61,7 +61,8 @@ mavenPublishing {
     coordinates("$group.core", name, version.toString())
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
-    signAllPublications()
+    if (project.hasProperty("signMavenPackages"))
+        signAllPublications()
 
     pom {
         name.set("Processing IO")

--- a/java/libraries/net/build.gradle.kts
+++ b/java/libraries/net/build.gradle.kts
@@ -53,7 +53,8 @@ mavenPublishing {
     coordinates("$group.core", name, version.toString())
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
-    signAllPublications()
+    if (project.hasProperty("signMavenPackages"))
+        signAllPublications()
 
     pom {
         name.set("Processing Net")

--- a/java/libraries/pdf/build.gradle.kts
+++ b/java/libraries/pdf/build.gradle.kts
@@ -55,7 +55,8 @@ mavenPublishing{
     coordinates("$group.core", name, version.toString())
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
-    signAllPublications()
+    if (project.hasProperty("signMavenPackages"))
+        signAllPublications()
 
     pom{
         name.set("Processing PDF")

--- a/java/libraries/serial/build.gradle.kts
+++ b/java/libraries/serial/build.gradle.kts
@@ -55,7 +55,8 @@ mavenPublishing {
     coordinates("$group.core", name, version.toString())
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
-    signAllPublications()
+    if (project.hasProperty("signMavenPackages"))
+        signAllPublications()
 
     pom {
         name.set("Processing Serial")

--- a/java/libraries/svg/build.gradle.kts
+++ b/java/libraries/svg/build.gradle.kts
@@ -55,7 +55,8 @@ mavenPublishing {
     coordinates("$group.core", name, version.toString())
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
-    signAllPublications()
+    if (project.hasProperty("signMavenPackages"))
+        signAllPublications()
 
     pom {
         name.set("Processing SVG")

--- a/java/preprocessor/build.gradle.kts
+++ b/java/preprocessor/build.gradle.kts
@@ -50,7 +50,7 @@ mavenPublishing{
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
     // Only sign if signing is set up
-    if(project.hasProperty("signing.keyId") || project.hasProperty("signingInMemoryKey"))
+    if (project.hasProperty("signing.signMavenPackages"))
         signAllPublications()
 
     pom{


### PR DESCRIPTION
Add creation of sketch/gradle.properties in ProcessingPluginTest, writing processing.group derived from System.getProperty("project.group").replace(".java", ""). This ensures the test project has the expected processing.group property within the tests

Closes #1485 