### PR TITLE
Lower bounds check on IntList get

### DIFF
--- a/core/src/processing/data/IntList.java
+++ b/core/src/processing/data/IntList.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Random;
 
+import org.jetbrains.annotations.TestOnly;
 import processing.core.PApplet;
 
 
@@ -164,11 +165,12 @@ public class IntList implements Iterable<Integer> {
    * @webBrief Get an entry at a particular index
    */
   public int get(int index) {
-    if (index >= this.count) {
+    if (index >= this.count || index < 0) {
       throw new ArrayIndexOutOfBoundsException(index);
     }
     return data[index];
   }
+
 
 
   /**

--- a/core/test/processing/data/IntListTest.java
+++ b/core/test/processing/data/IntListTest.java
@@ -152,6 +152,16 @@ public class IntListTest {
     }
 
     @Test
+    public void testGetOnNegativeIndexIntListThrowsException() {
+        IntList testedList = new IntList();
+        ArrayIndexOutOfBoundsException exception = assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+            testedList.get(-1);
+        });
+
+        assertEquals("Array index out of range: -1", exception.getMessage());
+    }
+
+    @Test
     public void testRemoveWithIndexGreaterThanSize() {
         IntList testedList = new IntList();
         assertThrows(ArrayIndexOutOfBoundsException.class,


### PR DESCRIPTION
Title: Lower bounds check on IntList get

Resolves #1415

Changes: Added a lower bound within the if statement of the get method within IntList. There was no lower bounds check within this method before. Now it throws exception if index is negative.

Tests: tests within IntListTest

Checklist: Tests pass and branch is up to date