### PR TITLE
Resolves: #1414 Missing hashCode on Sketch

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -1929,4 +1929,10 @@ public class Sketch {
     }
     return false;
   }
+
+
+  @Override
+  public int hashCode(){
+      return getMainPath().hashCode();
+  }
 }


### PR DESCRIPTION
Resolves #1414 

Changes: Implemented an override method for hashCode() on line 1934 in Sketch.java that returns the hash of mainPath. This ensures that two equal Sketch objects will produce the same hash code. 

Tests: Wrote tests, but did not include them as they're currently broken.

Checklist: Ensure tests pass (N/A) and the branch is up to date 