### PR TITLE
add codesign verify step for mac builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -390,6 +390,25 @@ afterEvaluate{
     }
 }
 
+val verifySignedMacApp = tasks.register<Exec>("verifySignedMacApp") {
+    onlyIf { OperatingSystem.current().isMacOsX }
+    dependsOn("createDistributable")
+    group = "compose desktop"
+
+    commandLine(
+        "codesign",
+        "-vvv",
+        "--deep",
+        "--strict",
+        layout.buildDirectory.dir("compose/binaries/main/app/Processing.app").get().asFile.absolutePath
+    )
+}
+
+afterEvaluate {
+    tasks.named("notarizeDmg").configure {
+        dependsOn(verifySignedMacApp)
+    }
+}
 
 // LEGACY TASKS
 // Most of these are shims to be compatible with the old build system


### PR DESCRIPTION
and use verbose output so that during release actions, someone can get a little info to debug the issue even if they don't have a mac.

this ended up being implemented in the gradle build file instead of the release.yml file, because the Build with Gradle step (which is `./gradlew packageDistributionForCurrentOS`) includes both signing and notarization. to stop the build early if the app signing failed, the intervening check had to be inserted into the normal build process.