### PR TITLE
fix for #1507 - mac signing issues for release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,7 +186,7 @@ tasks.register<Exec>("packageCustomDmg"){
     onlyIf { OperatingSystem.current().isMacOsX }
     group = "compose desktop"
 
-    dependsOn(distributable(), "installCreateDmg")
+    dependsOn("signApp", "installCreateDmg")
 
     val packageName = distributable().packageName.get()
     val dir = distributable().destinationDir.get()
@@ -571,9 +571,35 @@ tasks.register("signResources"){
         }
         file(composeResources("Info.plist")).delete()
     }
-
-
 }
+
+/* for mac, perform one final signature of the whole app before submitting
+ * the app for notarization.
+ */
+tasks.register<Exec>("signApp"){
+    onlyIf {
+        OperatingSystem.current().isMacOsX
+            &&
+        compose.desktop.application.nativeDistributions.macOS.signing.sign.get()
+    }
+
+    group = "compose desktop"
+    dependsOn("createDistributable", "setExecutablePermissions")
+
+    val packageName = distributable().packageName.get()
+    val dir = distributable().destinationDir.get()
+    val app = dir.file("$packageName.app").asFile
+
+    commandLine(
+        "codesign",
+        "--timestamp",
+        "--force",
+        "--deep",
+        "--options=runtime",
+        "--sign", "Developer ID Application",
+        app)
+}
+
 tasks.register("setExecutablePermissions") {
     description = "Sets executable permissions on binaries in Processing.app resources"
     group = "compose desktop"


### PR DESCRIPTION
fixes issue #1507 with Mac app notarization failure by signing the whole app again after fileAssocations are made. Adds an extra step called 'signApp' to the build process for `./gradlew -m packageDistributionForCurrentOS` which depends on `createDistributable` and `setExecutablePermissions`.

Previously, release builds were failing because the .icns files for .pde, .pdex, and .pdez were added to the .app file after signing, when `fileAssocation` was called in `nativeDistributions`.

Most of this code was generated with Copilot, then I edited it for legibility. I asked Copilot a lot of questions about the order of operations for the build system and where the fileAssociations occurred, and feel confident that this is the right place in the process to re-sign the app. I also prodded Copilot to see if there were any other simpler options that didn't involve signing things a second time (outside of when jpackage does this automatically), but wasn't able to produce any other successful solutions.

I have only tested this on Mac, but the file type associations work and the app notarization completed successfully (though it took nearly 30 minutes to run the notarization).

pinging @catilac for review!