### PR TITLE
Autofill Comma Correction for Visual Studio Code Extension

### DIFF
--- a/java/src/processing/mode/java/lsp/PdeAdapter.java
+++ b/java/src/processing/mode/java/lsp/PdeAdapter.java
@@ -318,11 +318,15 @@ class PdeAdapter {
       for (char ch : chs) {
         if (ch == ',') {
           n += 1;
-          //insert += ",$" + n;
-          newInsert.append(",$").append(n);
+          /*
+          Append the comma and the LSP tabstop identifier, 
+          then skip appending the duplicate 'ch' character
+          */
+          newInsert.append(", $").append(n); 
+        } else {
+          //Only append the original character if it wasn't a comma
+          newInsert.append(ch);
         }
-        //insert += ch;
-        newInsert.append(ch);
       }
       insert = newInsert.toString();
     }


### PR DESCRIPTION
In the current release version of the Processing Visual Studio Code extension, a comma is given for each argument that a method takes, rather than putting one comma. This means when auto filling a method call that has 2 arguments, 2 commas will be put inside the method parameters when only one would be needed to separate the two values.