### PR TITLE
Fix REG_APP_DIR to support jpackage application launchers

### DIFF
--- a/app/src/processing/app/platform/WindowsPlatform.java
+++ b/app/src/processing/app/platform/WindowsPlatform.java
@@ -127,10 +127,10 @@ public class WindowsPlatform extends DefaultPlatform {
       File exeDir = jarDir.getParentFile();
 
       if (exeFileExists(exeDir)) return exeDir.getAbsolutePath(); // standard folder layout
-      if (exeFileExists(jarDir)) return jarDir.getAbsolutePath(); // fallback if exe is inside "app"
+      if (exeFileExists(jarDir)) return jarDir.getAbsolutePath(); // if exe and jar is in same folder
     } catch (java.net.URISyntaxException e) {
     }
-    return System.getProperty("user.dir");
+    return System.getProperty("user.dir"); // processing.exe not found
   }
 
   static final String REG_APP_DIR = getRegAppDir().replace('/', '\\');

--- a/app/src/processing/app/platform/WindowsPlatform.java
+++ b/app/src/processing/app/platform/WindowsPlatform.java
@@ -111,8 +111,29 @@ public class WindowsPlatform extends DefaultPlatform {
 //    { Base.CONTRIB_BUNDLE_EXT, "Processing Contribution Bundle" }
 //  };
 
-  static final String REG_APP_DIR =
-    System.getProperty("user.dir").replace('/', '\\');
+  static boolean exeFileExists(File folder) {
+    File exeFile = new File(folder, APP_NAME.toLowerCase() + ".exe");
+    return exeFile.exists();
+  }
+
+  static String getRegAppDir() {
+    try {
+      // Get the JAR file containing this class (WindowsPlatform)
+      File jarFile = new File(WindowsPlatform.class.getProtectionDomain().
+                              getCodeSource().getLocation().toURI());
+      // Get the JAR folder ("app" in the standard jpackage layout)
+      File jarDir = jarFile.getParentFile();
+      // Get the processing.exe folder (parent of "app" in the standard layout)
+      File exeDir = jarDir.getParentFile();
+
+      if (exeFileExists(exeDir)) return exeDir.getAbsolutePath(); // standard folder layout
+      if (exeFileExists(jarDir)) return jarDir.getAbsolutePath(); // fallback if exe is inside "app"
+    } catch (java.net.URISyntaxException e) {
+    }
+    return System.getProperty("user.dir");
+  }
+
+  static final String REG_APP_DIR = getRegAppDir().replace('/', '\\');
   static final String REG_OPEN_COMMAND =
     REG_APP_DIR + "\\" + APP_NAME.toLowerCase() + ".exe \"%1\"";
   static final String[] APP_SCHEMES = { "pde" };  // use pde://

--- a/app/src/processing/app/platform/WindowsPlatform.java
+++ b/app/src/processing/app/platform/WindowsPlatform.java
@@ -127,7 +127,7 @@ public class WindowsPlatform extends DefaultPlatform {
       File exeDir = jarDir.getParentFile();
 
       if (exeFileExists(exeDir)) return exeDir.getAbsolutePath(); // standard folder layout
-      if (exeFileExists(jarDir)) return jarDir.getAbsolutePath(); // if exe and jar is in same folder
+      if (exeFileExists(jarDir)) return jarDir.getAbsolutePath(); // if exe and jar are in same folder
     } catch (java.net.URISyntaxException e) {
     }
     return System.getProperty("user.dir"); // processing.exe not found


### PR DESCRIPTION
### Description
This PR fixes an issue where the file association fails when Processing is packaged and launched using `jpackage`.

Currently, `REG_APP_DIR` relies directly on `System.getProperty("user.dir")`. However, when launched via a `jpackage` generated launcher, `user.dir` points to the directory from which the application was invoked (e.g., the current terminal directory or shortcut location), rather than the actual installation directory of `processing.exe`. This causes incorrect registry paths to be registered in `checkAssociations()`.

Thus, launching via file association breaks the next launch via file association. And launching via shortcut fixes the file association. This has not surfaced as a major issue on Windows 11 because the File Manager can override registry-defined associations. However, it remains a hidden bug that this PR aims to fix.

### Changes

- Updated `REG_APP_DIR` to dynamically resolve the installation directory based on the location of the JAR file (via `WindowsPlatform.class`).
- Added a fallback to the original `user.dir` behavior in case `processing.exe` cannot be found relative to the JAR location.
- Kept the changes minimal to avoid any unexpected impact on the existing codebase.

This ensures that file associations (`.pde`, etc.) always register the correct absolute path of `processing.exe`, regardless of the working directory at launch.