### PR TITLE
Update window class in desktop file template

### DIFF
--- a/build/linux/desktop.template
+++ b/build/linux/desktop.template
@@ -9,4 +9,4 @@ Terminal=false
 Categories=Development;IDE;Programming;
 MimeType=text/x-processing;x-scheme-handler/pde;
 Keywords=sketching;software;animation;programming;coding;
-StartupWMClass=processing-app-ui-Splash
+StartupWMClass=processing-app-ProcessingKt


### PR DESCRIPTION
The window class of the Processing IDE in Linux recently changed from `processing-app-ui-Splash` to `processing-app-ProcessingKt`. This caused IDE windows not to be associated with Processing's application icon anymore (see screenshot).

<img width="453" height="279" alt="image" src="https://github.com/user-attachments/assets/0106e0d3-f1e7-48a1-8238-42314c628620" />

This PR fixes this by updating the `StartupWMClass` value in the desktop template file (*/build/linux/desktop.template*).