### PR TITLE
Gradle 9 compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -563,9 +563,7 @@ tasks.register("signResources"){
             exclude("*.so")
             exclude("*.dll")
         }.forEach{ file ->
-            exec {
-                commandLine("codesign", "--timestamp", "--force", "--deep","--options=runtime", "--entitlements", entitlements, "--sign", "Developer ID Application", file)
-            }
+            Runtime.getRuntime().exec(arrayOf("codesign", "--timestamp", "--force", "--deep", "--options=runtime", "--entitlements", entitlements, "--sign", "Developer ID Application", file.absolutePath))
         }
         jars.forEach { file ->
             FileOutputStream(File(file.parentFile, file.nameWithoutExtension)).use { fos ->


### PR DESCRIPTION
Currently the build process fails with Gradle 9 due to a depreciated statement in *app/build.gradle.kt*. The relevant part of the error message is:

```
Script compilation errors:

  Line 566:             exec {
                        ^ Unresolved reference 'exec'.

  Line 567:                 commandLine("codesign", "--timestamp", "--force", "--deep","--options=runtime", "--entitlements", entitlements, "--sign", "Developer ID Application", file)
                            ^ Unresolved reference 'commandLine'.

2 errors
```

This PR enables Gradle 9 compatibility by replacing the `commandLine(...)` statement with `Runtime.getRuntime().exec(arrayOf(...))`. After this, the build process runs smoothly on Linux.

**Important:** Even though I am pretty sure that the new statement will work, I was not able to test it on MacOS, which seems to be the only system that actually executes the modified line. This should be done by a reviewer before merging the PR.