### PR TITLE
Add a fallback for when project version is `unspecified`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,7 @@ dependencies {
 }
 
 tasks.test {
+    systemProperty("java.awt.headless", "true")
     useJUnitPlatform()
     workingDir = file("build/test")
     workingDir.mkdirs()

--- a/app/src/processing/app/ui/PDEWelcome.kt
+++ b/app/src/processing/app/ui/PDEWelcome.kt
@@ -39,6 +39,7 @@ import processing.app.*
 import processing.app.api.Contributions.ExamplesList.Companion.listAllExamples
 import processing.app.api.Sketch.Companion.Sketch
 import processing.app.ui.theme.*
+import java.awt.GraphicsEnvironment
 import java.io.File
 import kotlin.io.path.Path
 import kotlin.io.path.exists
@@ -554,10 +555,14 @@ fun Sketch.card(onOpen: () -> Unit = {}) {
 }
 
 fun noBaseWarning() {
-    Messages.showWarning(
-        "No Base",
-        "No Base instance provided, this ui is likely being previewed."
-    )
+    if (Base.isCommandLine() || GraphicsEnvironment.isHeadless()) {
+        System.err.println("No Base instance provided, this ui is likely being previewed");
+    } else {
+        Messages.showWarning(
+            "No Base",
+            "No Base instance provided, this ui is likely being previewed."
+        )
+    }
 }
 
 val size = DpSize(970.dp, 600.dp)

--- a/java/gradle/src/main/kotlin/ProcessingPlugin.kt
+++ b/java/gradle/src/main/kotlin/ProcessingPlugin.kt
@@ -23,7 +23,7 @@ class ProcessingPlugin @Inject constructor(private val objectFactory: ObjectFact
         val processingVersion = project.findProperty("processing.version") as String?
             ?: javaClass.classLoader.getResourceAsStream("version.properties")?.use { stream ->
                 java.util.Properties().apply { load(stream) }.getProperty("version")
-            } ?: "4.3.4"
+            }?.takeIf { it != "unspecified" } ?: "4.5.5"
         val processingGroup = project.findProperty("processing.group") as String? ?: "org.processing"
         val workingDir = project.findProperty("processing.workingDir") as String?
         val debugPort = project.findProperty("processing.debugPort") as String?


### PR DESCRIPTION
This is a patch for when `processing.version` is unspecified. I do want to fix the configurations so that we don't have that state. But for now this will fix the broken ProcessingPluginTests.

Also fixes PDEWelcomeTests which need to be run headless.