### PR TITLE
Some tokens used as variable names incorrectly reported as errors

### DIFF
--- a/java/preprocessor/src/main/antlr/processing/mode/java/preproc/Processing.g4
+++ b/java/preprocessor/src/main/antlr/processing/mode/java/preproc/Processing.g4
@@ -53,7 +53,7 @@ warnMixedModes
 
 variableDeclaratorId
     : warnTypeAsVariableName
-    | IDENTIFIER ('[' ']')*
+    | identifier ('[' ']')*
     ;
 
 // bug #93
@@ -68,7 +68,7 @@ warnTypeAsVariableName
 // catch special API function calls that we are interested in
 methodCall
     : functionWithPrimitiveTypeName
-    | IDENTIFIER '(' expressionList? ')'
+    | identifier '(' expressionList? ')'
     | THIS '(' expressionList? ')'
     | SUPER '(' expressionList? ')'
     ;
@@ -103,7 +103,7 @@ colorPrimitiveType
     ;
 
 qualifiedName
-    : (IDENTIFIER | colorPrimitiveType) ('.' (IDENTIFIER | colorPrimitiveType))*
+    : (identifier | colorPrimitiveType) ('.' (identifier | colorPrimitiveType))*
     ;
 
 // added HexColorLiteral

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -284,6 +284,11 @@ public class ParserTests {
   }
 
   @Test
+  public void bug1501() {
+    expectGood("bug1501");
+  }
+
+  @Test
   public void bug1534() {
     expectGood("bug1534");
   }

--- a/java/test/resources/bug1501.expected
+++ b/java/test/resources/bug1501.expected
@@ -1,0 +1,51 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class bug1501 extends PApplet {
+
+float to;
+Module module;
+
+public void setup() {
+  /* size commented out by preprocessor */;
+  int open = 1;
+  String with = "with";
+  to = 5.0f;
+  module = new Module();
+  int transitive = open + 2;
+  println(to, with, transitive);
+  provides();
+}
+
+public void provides() {
+  int record = 2;
+  int permits = record + 1;
+  println(permits);
+}
+
+class Module {
+}
+
+
+    public void settings() { size(400, 400); }
+
+    static public void main(String[] passedArgs) {
+        String[] appletArgs = new String[] { "bug1501" };
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+    }
+}

--- a/java/test/resources/bug1501.pde
+++ b/java/test/resources/bug1501.pde
@@ -1,0 +1,22 @@
+float to;
+Module module;
+
+void setup() {
+  size(400, 400);
+  int open = 1;
+  String with = "with";
+  to = 5.0;
+  module = new Module();
+  int transitive = open + 2;
+  println(to, with, transitive);
+  provides();
+}
+
+void provides() {
+  int record = 2;
+  int permits = record + 1;
+  println(permits);
+}
+
+class Module {
+}


### PR DESCRIPTION
Fixes #1501.

We need to swap from the lexer to the `identifier` parser rule, which correctly only excludes actual reserved keywords. The upstream grammar started tokenizing all the contextual java module stuff, which broke people using `to`, `module`, etc. Broken since 00e424337 afaict.