### PR TITLE
fix #1520

### DIFF
--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -5512,8 +5512,11 @@ public class PGraphicsOpenGL extends PGraphics {
                          int targetX, int targetY) {
     updatePixelSize();
 
-    // Copies the pixels
+    // make sure pixel arrays are available
     loadPixels();
+    sourceImage.loadPixels();
+
+    // Copies the pixels
     int sourceOffset = sourceY * sourceImage.pixelWidth + sourceX;
     int targetOffset = targetY * pixelWidth + targetX;
     for (int y = sourceY; y < sourceY + sourceHeight; y++) {


### PR DESCRIPTION
Fix the `set()` method when passing a `PImage` that is a `PGraphicsOpenGL` instance. This ensures that the pixels are loaded and there is no null pointer exception.