### PR TITLE
Fix "InaccessibleObjectException" exception on Linux startup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,7 +104,8 @@ compose.desktop {
                 iconFile = rootProject.file("build/linux/processing.png")
                 // Fix fonts on some Linux distributions
                 jvmArgs("-Dawt.useSystemAAFontSettings=on")
-
+                // Enable access to restricted methods; see initBase in LinuxPlatform.java
+                jvmArgs("--add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED")
             }
         }
     }


### PR DESCRIPTION
Linux builds would previously throw this error on startup:
> java.lang.reflect.InaccessibleObjectException: Unable to make field private
> static java.lang.String sun.awt.X11.XToolkit.awtAppClassName accessible:
> module java.desktop does not "opens sun.awt.X11" to unnamed module @4c8aea9c

The code that triggered this in Processing itself documented that an `--add-opens` parameter must be used, but this was never applied in the gradle build. This now matches the `--add-opens` parameter used in `build/linux/processing`.

Comment from LinuxPlatform.java:
>    // Set X11 WM_CLASS property which is used as the application
>    // name by Gnome 3 and other window managers.
>    // https://github.com/processing/processing/issues/2534
>    // For Java 17, this hack requires an addition to the command line:
>    // --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED
